### PR TITLE
Require :name option for LiveDashboard agent and route

### DIFF
--- a/lib/phoenix/live_dashboard/telemetry_live.ex
+++ b/lib/phoenix/live_dashboard/telemetry_live.ex
@@ -1,12 +1,11 @@
 defmodule Phoenix.LiveDashboard.TelemetryLive do
   @moduledoc false
   use Phoenix.LiveView
-  alias Phoenix.LiveDashboard
   alias Phoenix.LiveDashboard.LiveMetric
 
   @impl true
-  def mount(_session, socket) do
-    metrics = Agent.get(LiveDashboard, & &1.metrics, 1_000)
+  def mount(%{"name" => agent_name}, socket) do
+    metrics = Agent.get(agent_name, & &1.metrics, 1_000)
     groups = Enum.group_by(metrics, & &1.event_name)
     channel = self()
 


### PR DESCRIPTION
Preparation for multiple dashboards.

@chrismccord FYI right now I can't actually define two dashboards in the example app.  Given a router config like this:

```ex
forward "/dashboard", Phoenix.LiveDashboard,
  name: DashboardApp.DashboardA,
  router: __MODULE__

forward "/dashboard2", Phoenix.LiveDashboard,
  name: DashboardApp.DashboardB,
  router: __MODULE__
```

I get the following error:

```ex
** (ArgumentError) Phoenix.LiveDashboard has already been forwarded to. A module can only be forwarded a single time.
    (phoenix) lib/phoenix/router/route.ex:169: Phoenix.Router.Route.forward_path_segments/3
    (phoenix) lib/phoenix/router/scope.ex:132: Phoenix.Router.Scope.register_forwards/3
    lib/dashboard_app_web/router.ex:31: (module)
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
```

This makes sense, but let me know what we'd want to do in practice.