### PR TITLE
Updated README to include details on metrics (from Guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ if Mix.env() == :dev do
 
   scope "/" do
     pipe_through :browser
-    live_dashboard "/dashboard"
+    live_dashboard "/dashboard", metrics: MyAppWeb.Telemetry
   end
 end
 ```
+
+Define [MyAppWeb.Telemetry](https://hexdocs.pm/phoenix_live_dashboard/metrics.html#define-your-telemetry-module) 
 
 This is all. Run `mix phx.server` and access the "/dashboard" to configure the necessary modules.
 


### PR DESCRIPTION
I updated the README to match the Guide for metrics so that the Dashboard would load. I added a sentence after it to show that you would then need to create the MyAppWeb.Telemetry (I think I got the URL right for it).