### PR TITLE
Fixes compiler error on Elixir 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x, 22.x]
-        elixir: [1.8.x, 1.9.x, 1.10.x]
+        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -76,7 +76,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
     processes =
       for pid <- Process.list(), info = Process.info(pid, @process_info) do
-        [registered_name: name, initial_call: initial_call] ++ rest = info
+        [{:registered_name, name}, {:initial_call, initial_call} | rest] = info
         name_or_initial_call = if is_atom(name), do: name, else: initial_call
         sorter = info[sort_by] * multiplier
         {sorter, [pid: pid, name_or_initial_call: name_or_initial_call] ++ rest}


### PR DESCRIPTION
When running on Elixir 1.7, the following compilation error is raised

    == Compilation error in file lib/phoenix/live_dashboard/system_info.ex ==
    ** (CompileError) lib/phoenix/live_dashboard/system_info.ex:79: illegal pattern
        (stdlib) lists.erl:1338: :lists.foreach/2
        (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
        (elixir) lib/kernel/parallel_compiler.ex:206: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6

This fixes that compiler error and adds Elixir 1.7 to the test matrix.