### PR TITLE
Use camelize format for metric group names

### DIFF
--- a/lib/phoenix/live_dashboard/live/metrics_live.ex
+++ b/lib/phoenix/live_dashboard/live/metrics_live.ex
@@ -38,10 +38,8 @@ defmodule Phoenix.LiveDashboard.MetricsLive do
     to_string(metric.reporter_options[:group] || hd(metric.name))
   end
 
-  def format_group_name("phoenix"), do: "Phoenix metrics"
-  def format_group_name("vm"), do: "VM metrics"
-
-  def format_group_name(group_name), do: "#{inspect(group_name)} metrics"
+  defp format_group_name("vm"), do: "VM"
+  defp format_group_name(group), do: Phoenix.Naming.camelize(group)
 
   @impl true
   def render(assigns) do

--- a/test/phoenix/live_dashboard/live/metrics_live_test.exs
+++ b/test/phoenix/live_dashboard/live/metrics_live_test.exs
@@ -14,8 +14,9 @@ defmodule Phoenix.LiveDashboard.MetricsLiveTest do
     {:ok, live, _} = live(build_conn(), "/dashboard/nonode@nohost/metrics/phx")
     rendered = render(live)
     assert rendered =~ "Updates automatically"
-    assert rendered =~ "&quot;phx&quot; metrics"
-    assert rendered =~ "&quot;ecto&quot; metrics"
+    assert rendered =~ "Phx"
+    assert rendered =~ "Ecto"
+    assert rendered =~ "MyApp"
     assert rendered =~ ~s|data-title="phx.b.c"|
     assert rendered =~ ~s|data-title="phx.b.d"|
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,7 +22,8 @@ defmodule Phoenix.LiveDashboardTest.Telemetry do
     [
       counter("phx.b.c"),
       counter("phx.b.d"),
-      counter("ecto.f.g")
+      counter("ecto.f.g"),
+      counter("my_app.h.i")
     ]
   end
 end


### PR DESCRIPTION
Rather than special-casing these as we go, using `camelize` should cover 99% of the metrics names we might receive.  I also dropped the suffix to save space, but I can bring it back if preferred.

<img width="327" alt="Screen Shot 2020-04-04 at 11 21 08 PM" src="https://user-images.githubusercontent.com/168677/78468422-dd835880-76cc-11ea-9226-794af5ad6354.png">

vs.

<img width="316" alt="Screen Shot 2020-04-04 at 11 21 35 PM" src="https://user-images.githubusercontent.com/168677/78468423-e116df80-76cc-11ea-9607-7d5758184997.png">
