### PR TITLE
Simpler way to make the legend show iso formats for timestamps

### DIFF
--- a/assets/js/metrics_live/index.js
+++ b/assets/js/metrics_live/index.js
@@ -10,13 +10,9 @@ const SeriesValue = (options) => {
   }
 }
 
-const XSeriesValue = (options) => {
+const XSeriesValue = (_options) => {
   return {
-    value: (self, v) => {
-      if (v === null) return '';
-      let d = new Date(v * 1e3)
-      return uPlot.fmtDate('{YYYY}-{MM}-{DD} {HH}:{mm}:{ss}')(d)
-    }
+    value: '{YYYY}-{MM}-{DD} {HH}:{mm}:{ss}'
   }
 }
 


### PR DESCRIPTION
Implement the improvement suggested by @leeoniya in #55 