### PR TITLE
Use @external_resource in top-level moduledoc

### DIFF
--- a/lib/phoenix/live_dashboard.ex
+++ b/lib/phoenix/live_dashboard.ex
@@ -1,5 +1,6 @@
 defmodule Phoenix.LiveDashboard do
-  @moduledoc "README.md"
+  @external_resource "README.md"
+  @moduledoc @external_resource
              |> File.read!()
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)


### PR DESCRIPTION
So that `Phoenix.LiveDashboard` recompiles if README changes.