### PR TITLE
Add sockets table

### DIFF
--- a/lib/phoenix/live_dashboard/live/menu_live.ex
+++ b/lib/phoenix/live_dashboard/live/menu_live.ex
@@ -26,6 +26,7 @@ defmodule Phoenix.LiveDashboard.MenuLive do
       <%= maybe_active_live_redirect @socket, @menu, "Processes", :processes, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Ports", :ports, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "ETS", :ets, @node %>
+      <%= maybe_active_live_redirect @socket, @menu, "Sockets", :sockets, @node %>
     </nav>
 
     <form id="node-selection" phx-change="select_node" class="d-inline">

--- a/lib/phoenix/live_dashboard/live/menu_live.ex
+++ b/lib/phoenix/live_dashboard/live/menu_live.ex
@@ -25,8 +25,8 @@ defmodule Phoenix.LiveDashboard.MenuLive do
       <%= maybe_enabled_live_redirect @socket, @menu, "Request Logger", :request_logger, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Processes", :processes, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Ports", :ports, @node %>
-      <%= maybe_active_live_redirect @socket, @menu, "ETS", :ets, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Sockets", :sockets, @node %>
+      <%= maybe_active_live_redirect @socket, @menu, "ETS", :ets, @node %>
     </nav>
 
     <form id="node-selection" phx-change="select_node" class="d-inline">

--- a/lib/phoenix/live_dashboard/live/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/live/socket_info_component.ex
@@ -1,0 +1,77 @@
+defmodule Phoenix.LiveDashboard.SocketInfoComponent do
+  use Phoenix.LiveDashboard.Web, :live_component
+  import Phoenix.LiveDashboard.TableHelpers
+  alias Phoenix.LiveDashboard.SystemInfo
+
+  @info_keys [
+    :module,
+    :send_oct,
+    :recv_oct,
+    :local_address,
+    :foreign_address,
+    :state,
+    :type,
+    :connected
+  ]
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="tabular-info">
+      <%= if @alive do %>
+        <table class="table table-hover tabular-info-table">
+          <tbody>
+            <tr><td class="border-top-0">Module</td><td class="border-top-0"><%= @module %></td></tr>
+            <tr><td>Sent</td><td><%= @send_oct %></td></tr>
+            <tr><td>Received</td><td><%= @recv_oct %></td></tr>
+            <tr><td>State</td><td><%= @state %></td></tr>
+            <tr><td>Type</td><td><%= @type %></td></tr>
+            <tr><td>Owner</td><td><%= @connected %></td></tr>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="tabular-info-exits mt-1 mb-3">Port was closed or does not exist.</div>
+      <% end %>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok, Enum.reduce(@info_keys, socket, &assign(&2, &1, nil))}
+  end
+
+  @impl true
+  def update(%{port: port} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(port: port)
+     |> assign_info()}
+  end
+
+  defp assign_info(%{assigns: assigns} = socket) do
+    case SystemInfo.fetch_socket_info(assigns.port, @info_keys) do
+      :error ->
+        assign(socket, alive: false)
+
+      info ->
+        Enum.reduce(info, socket, fn {key, val}, acc ->
+          assign(acc, key, format_info(key, val, assigns.live_dashboard_path))
+        end)
+        |> assign(alive: true)
+    end
+  end
+
+  defp format_info(key, val, live_dashboard_path)
+       when key in [:send_oct, :recv_oct],
+       do: format_bytes(val)
+
+  defp format_info(key, val, live_dashboard_path)
+       when key in [:connected, :port],
+       do: format_value(val, live_dashboard_path)
+
+  defp format_info(key, val, _live_dashboard_path)
+       when key in [:module, :local_address, :foreign_address, :state, :type],
+       do: val
+end

--- a/lib/phoenix/live_dashboard/live/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/live/socket_info_component.ex
@@ -20,14 +20,14 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
       <%= if @alive do %>
         <table class="table table-hover tabular-info-table">
           <tbody>
-            <tr><td class="border-top-0">Module</td><td class="border-top-0"><%= @module %></td></tr>
+            <tr><td class="border-top-0">Module</td><td class="border-top-0"><pre><%= @module %></pre></td></tr>
             <tr><td>Sent</td><td><%= @send_oct %></td></tr>
             <tr><td>Received</td><td><%= @recv_oct %></td></tr>
             <tr><td>Local Address</td><td><%= @local_address %></td></tr>
             <tr><td>Foreign Address</td><td><%= @foreign_address %></td></tr>
             <tr><td>State</td><td><%= @state %></td></tr>
             <tr><td>Type</td><td><%= @type %></td></tr>
-            <tr><td>Owner</td><td><%= @connected %></td></tr>
+            <tr><td>Owner</td><td><pre><%= @connected %></pre></td></tr>
           </tbody>
         </table>
       <% else %>

--- a/lib/phoenix/live_dashboard/live/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/live/socket_info_component.ex
@@ -1,6 +1,5 @@
 defmodule Phoenix.LiveDashboard.SocketInfoComponent do
   use Phoenix.LiveDashboard.Web, :live_component
-  import Phoenix.LiveDashboard.TableHelpers
   alias Phoenix.LiveDashboard.SystemInfo
 
   @info_keys [
@@ -24,6 +23,8 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
             <tr><td class="border-top-0">Module</td><td class="border-top-0"><%= @module %></td></tr>
             <tr><td>Sent</td><td><%= @send_oct %></td></tr>
             <tr><td>Received</td><td><%= @recv_oct %></td></tr>
+            <tr><td>Local Address</td><td><%= @local_address %></td></tr>
+            <tr><td>Foreign Address</td><td><%= @foreign_address %></td></tr>
             <tr><td>State</td><td><%= @state %></td></tr>
             <tr><td>Type</td><td><%= @type %></td></tr>
             <tr><td>Owner</td><td><%= @connected %></td></tr>
@@ -63,7 +64,7 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
     end
   end
 
-  defp format_info(key, val, live_dashboard_path)
+  defp format_info(key, val, _live_dashboard_path)
        when key in [:send_oct, :recv_oct],
        do: format_bytes(val)
 

--- a/lib/phoenix/live_dashboard/live/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/live/socket_info_component.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
       :error ->
         assign(socket, alive: false)
 
-      info ->
+      {:ok, info} ->
         Enum.reduce(info, socket, fn {key, val}, acc ->
           assign(acc, key, format_info(key, val, assigns.live_dashboard_path))
         end)

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   alias Phoenix.LiveDashboard.SystemInfo
 
-  @sort_by ~w(recv sent state)
+  @sort_by ~w(recv_oct send_oct)
 
   @tttt """
     port
@@ -32,7 +32,9 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
   The connection state.
 
   type
+  STREAM or DGRAM or SEQPACKET.
   """
+
   @impl true
   def mount(%{"node" => _} = params, session, socket) do
     {:ok, assign_defaults(socket, params, session, true)}
@@ -43,7 +45,6 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
     {:noreply,
      socket
      |> assign_params(params, @sort_by)
-     |> assign_ref(params)
      |> fetch_sockets()}
   end
 
@@ -98,17 +99,17 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <th>x</th>
                   <th>x</th>
                   <th>
-                    <%= sort_link(@socket, @live_action, @menu, @params, :sent, "Sent") %>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :send_oct, "Send") %>
                   </th>
                   <th>
-                    <%= sort_link(@socket, @live_action, @menu, @params, :recv, "Received") %>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :recv_oct, "Received") %>
                   </th>
                   <th>x</th>
                 </tr>
               </thead>
               <tbody>
-                <%= for socket <- @sockets, list_ref = socket[:id] do %>
-                  <tr phx-click="show_info" phx-value-ref="<%= list_ref %>" phx-page-loading>
+                <%= for socket <- @sockets do %>
+                  <tr phx-page-loading>
                     <td class="tabular-column-name pl-4"><%= socket[:id] %></td>
                     <td></td>
                     <td></td>
@@ -155,28 +156,9 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
     live_dashboard_path(socket, :processes, node, [pid])
   end
 
-  defp assign_ref(socket, %{"ref" => ref_param}) do
-    assign(socket, ref: decode_reference(ref_param))
-  end
-
-  defp assign_ref(socket, %{}), do: assign(socket, ref: nil)
-
   defp return_path(socket, menu, params) do
     self_path(socket, menu.node, params)
   end
-
-  @doc false
-  def encode_reference(ref) do
-    ref
-    |> :erlang.ref_to_list()
-    |> Enum.drop(5)
-    |> Enum.drop(-1)
-    |> List.to_string()
-  end
-
-  @doc false
-  def decode_reference(list_ref),
-    do: :erlang.list_to_ref(String.to_charlist("#Ref<") ++ String.to_charlist(list_ref) ++ [?>])
 
   @doc false
   def encode_pid(pid) do

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   alias Phoenix.LiveDashboard.SystemInfo
 
-  @sort_by ~w(recv_oct send_oct)
+  @sort_by ~w(recv_oct send_oct local_address foreign_address)
 
   @tttt """
     port
@@ -99,12 +99,17 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <th>x</th>
                   <th>x</th>
                   <th>
-                    <%= sort_link(@socket, @live_action, @menu, @params, :send_oct, "Send") %>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :send_oct, "Sent") %>
                   </th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :recv_oct, "Received") %>
                   </th>
-                  <th>x</th>
+                  <th>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :local_address, "Local Address") %>
+                  </th>
+                  <th>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :foreign_address, "Foreign Address") %>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -115,7 +120,8 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                     <td></td>
                     <td><%= socket[:send_oct] %></td>
                     <td><%= socket[:recv_oct] %></td>
-                    <td></td>
+                    <td><%= socket[:local_address] %></td>
+                    <td><%= socket[:foreign_address] %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -167,15 +167,6 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
     live_dashboard_path(socket, :sockets, node, [], params)
   end
 
-  def pid_path(socket, pid) do
-    node = node(decode_pid(pid))
-    live_dashboard_path(socket, :processes, node, [pid])
-  end
-
-  defp return_path(socket, menu, params) do
-    self_path(socket, menu.node, params)
-  end
-
   defp format_address({:error, :enotconn}), do: "*:*"
   defp format_address({:error, _}), do: " "
 

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -6,35 +6,6 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   @sort_by ~w(module recv_oct send_oct connected local_address foreign_address state type)
 
-  @tttt """
-    port
-    The internal index of the port.
-
-    module
-    The callback module of the socket.
-
-    recv
-    Number of bytes received by the socket.
-
-    sent
-    Number of bytes sent from the socket.
-
-    owner
-    The socket owner process.
-
-    local_address
-    The local address of the socket.
-
-    foreign_address
-    The address and port of the other end of the connection.
-
-    state
-    The connection state.
-
-    type
-    STREAM or DGRAM or SEQPACKET.
-  """
-
   @impl true
   def mount(%{"node" => _} = params, session, socket) do
     {:ok, assign_defaults(socket, params, session, true)}

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -165,16 +165,4 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
   defp return_path(socket, menu, params) do
     self_path(socket, menu.node, params)
   end
-
-  @doc false
-  def encode_pid(pid) do
-    pid
-    |> :erlang.pid_to_list()
-    |> tl()
-    |> Enum.drop(-1)
-    |> List.to_string()
-  end
-
-  @doc false
-  def decode_pid(list_pid), do: :erlang.list_to_pid([?<] ++ String.to_charlist(list_pid) ++ [?>])
 end

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -1,0 +1,192 @@
+defmodule Phoenix.LiveDashboard.SocketsLive do
+  use Phoenix.LiveDashboard.Web, :live_view
+  import Phoenix.LiveDashboard.TableHelpers
+
+  alias Phoenix.LiveDashboard.SystemInfo
+
+  @sort_by ~w(recv sent state)
+
+  @tttt """
+    port
+  The internal index of the port.
+
+  module
+  The callback module of the socket.
+
+  recv
+  Number of bytes received by the socket.
+
+  sent
+  Number of bytes sent from the socket.
+
+  owner
+  The socket owner process.
+
+  local_address
+  The local address of the socket.
+
+  foreign_address
+  The address and port of the other end of the connection.
+
+  state
+  The connection state.
+
+  type
+  """
+  @impl true
+  def mount(%{"node" => _} = params, session, socket) do
+    {:ok, assign_defaults(socket, params, session, true)}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply,
+     socket
+     |> assign_params(params, @sort_by)
+     |> assign_ref(params)
+     |> fetch_sockets()}
+  end
+
+  defp fetch_sockets(socket) do
+    %{search: search, sort_by: sort_by, sort_dir: sort_dir, limit: limit} = socket.assigns.params
+
+    {sockets, total} =
+      SystemInfo.fetch_sockets(socket.assigns.menu.node, search, sort_by, sort_dir, limit)
+
+    assign(socket, sockets: sockets, total: total)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="tabular-page">
+      <h5 class="card-title">Sockets</h5>
+
+      <div class="tabular-search">
+        <form phx-change="search" phx-submit="search" class="form-inline">
+          <div class="form-row align-items-center">
+            <div class="col-auto">
+              <input type="search" name="search" class="form-control form-control-sm" value="<%= @params.search %>" placeholder="Search by name or module" phx-debounce="300">
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <form phx-change="select_limit" class="form-inline">
+        <div class="form-row align-items-center">
+          <div class="col-auto">Showing at most</div>
+          <div class="col-auto">
+            <div class="input-group input-group-sm">
+              <select name="limit" class="custom-select" id="limit-select">
+                <%= options_for_select(limit_options(), @params.limit) %>
+              </select>
+            </div>
+          </div>
+          <div class="col-auto">
+            tables out of <%= @total %>
+          </div>
+        </div>
+      </form>
+
+      <div class="card tabular-card mb-4 mt-4">
+        <div class="card-body p-0">
+          <div class="dash-table-wrapper">
+            <table class="table table-hover mt-0 dash-table clickable-rows">
+              <thead>
+                <tr>
+                  <th class="pl-4">Port ID</th>
+                  <th>x</th>
+                  <th>x</th>
+                  <th>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :sent, "Sent") %>
+                  </th>
+                  <th>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :recv, "Received") %>
+                  </th>
+                  <th>x</th>
+                </tr>
+              </thead>
+              <tbody>
+                <%= for socket <- @sockets, list_ref = socket[:id] do %>
+                  <tr phx-click="show_info" phx-value-ref="<%= list_ref %>" phx-page-loading>
+                    <td class="tabular-column-name pl-4"><%= socket[:id] %></td>
+                    <td></td>
+                    <td></td>
+                    <td><%= socket[:send_oct] %></td>
+                    <td><%= socket[:recv_oct] %></td>
+                    <td></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_info({:node_redirect, node}, socket) do
+    {:noreply, push_redirect(socket, to: self_path(socket, node, socket.assigns.params))}
+  end
+
+  def handle_info(:refresh, socket) do
+    {:noreply, fetch_sockets(socket)}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    %{menu: menu, params: params} = socket.assigns
+    {:noreply, push_patch(socket, to: self_path(socket, menu.node, %{params | search: search}))}
+  end
+
+  def handle_event("select_limit", %{"limit" => limit}, socket) do
+    %{menu: menu, params: params} = socket.assigns
+    {:noreply, push_patch(socket, to: self_path(socket, menu.node, %{params | limit: limit}))}
+  end
+
+  defp self_path(socket, node, params) do
+    live_dashboard_path(socket, :sockets, node, [], params)
+  end
+
+  def pid_path(socket, pid) do
+    node = node(decode_pid(pid))
+    live_dashboard_path(socket, :processes, node, [pid])
+  end
+
+  defp assign_ref(socket, %{"ref" => ref_param}) do
+    assign(socket, ref: decode_reference(ref_param))
+  end
+
+  defp assign_ref(socket, %{}), do: assign(socket, ref: nil)
+
+  defp return_path(socket, menu, params) do
+    self_path(socket, menu.node, params)
+  end
+
+  @doc false
+  def encode_reference(ref) do
+    ref
+    |> :erlang.ref_to_list()
+    |> Enum.drop(5)
+    |> Enum.drop(-1)
+    |> List.to_string()
+  end
+
+  @doc false
+  def decode_reference(list_ref),
+    do: :erlang.list_to_ref(String.to_charlist("#Ref<") ++ String.to_charlist(list_ref) ++ [?>])
+
+  @doc false
+  def encode_pid(pid) do
+    pid
+    |> :erlang.pid_to_list()
+    |> tl()
+    |> Enum.drop(-1)
+    |> List.to_string()
+  end
+
+  @doc false
+  def decode_pid(list_pid), do: :erlang.list_to_pid([?<] ++ String.to_charlist(list_pid) ++ [?>])
+end

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -4,35 +4,35 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   alias Phoenix.LiveDashboard.SystemInfo
 
-  @sort_by ~w(connected recv_oct send_oct local_address foreign_address state)
+  @sort_by ~w(module recv_oct send_oct connected local_address foreign_address state type)
 
   @tttt """
     port
-  The internal index of the port.
+    The internal index of the port.
 
-  module
-  The callback module of the socket.
+    module
+    The callback module of the socket.
 
-  recv
-  Number of bytes received by the socket.
+    recv
+    Number of bytes received by the socket.
 
-  sent
-  Number of bytes sent from the socket.
+    sent
+    Number of bytes sent from the socket.
 
-  owner
-  The socket owner process.
+    owner
+    The socket owner process.
 
-  local_address
-  The local address of the socket.
+    local_address
+    The local address of the socket.
 
-  foreign_address
-  The address and port of the other end of the connection.
+    foreign_address
+    The address and port of the other end of the connection.
 
-  state
-  The connection state.
+    state
+    The connection state.
 
-  type
-  STREAM or DGRAM or SEQPACKET.
+    type
+    STREAM or DGRAM or SEQPACKET.
   """
 
   @impl true
@@ -96,7 +96,9 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
               <thead>
                 <tr>
                   <th class="pl-4">Port ID</th>
-                  <th>x</th>
+                  <th>
+                  <%= sort_link(@socket, @live_action, @menu, @params, :module, "Module") %>
+                  </th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :send_oct, "Sent") %>
                   </th>
@@ -113,19 +115,23 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :state, "State") %>
                   </th>
+                  <th>
+                    <%= sort_link(@socket, @live_action, @menu, @params, :type, "Type") %>
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <%= for socket <- @sockets do %>
                   <tr phx-page-loading>
                     <td class="tabular-column-name pl-4"><%= socket[:id] %></td>
-                    <td></td>
+                    <td><%= socket[:module] %></td>
                     <td><%= format_bytes(socket[:send_oct]) %></td>
                     <td><%= format_bytes(socket[:recv_oct]) %></td>
                     <td><%= format_value(socket[:connected], &live_dashboard_path(@socket, &1, &2, &3, @params)) %></td>
                     <td><%= format_address(socket[:local_address]) %></td>
                     <td><%= format_address(socket[:foreign_address]) %></td>
                     <td><%= format_state(socket[:state]) %></td>
+                    <td><%= socket[:type] %></td>
                   </tr>
                 <% end %>
               </tbody>
@@ -199,46 +205,3 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
     end
   end
 end
-
-
-# %% Possible flags: (sorted)
-# %% [accepting,bound,busy,connected,connecting,listen,listening,open]
-# %% Actually, we no longer gets listening...
-# fmt_status(Flags) ->
-#     case lists:sort(Flags) of
-# 	[accepting | _]               -> "ACCEPTING";
-# 	[bound,busy,connected|_]      -> "CONNECTED(BB)";
-# 	[bound,connected|_]           -> "CONNECTED(B)";
-# 	[bound,listen,listening | _]  -> "LISTENING";
-# 	[bound,listen | _]            -> "LISTEN";
-# 	[bound,connecting | _]        -> "CONNECTING";
-# 	[bound,open]                  -> "BOUND";
-# 	[connected,open]              -> "CONNECTED(O)";
-# 	[open]                        -> "IDLE";
-# 	[]                            -> "CLOSED";
-# 	Sorted                        -> fmt_status2(Sorted)
-#     end.
-
-# fmt_status2([H]) ->
-#     fmt_status3(H);
-# fmt_status2([H|T]) ->
-#     fmt_status3(H) ++ ":"  ++ fmt_status2(T).
-
-# fmt_status3(accepting) ->
-#     "A";
-# fmt_status3(bound) ->
-#     "BD";
-# fmt_status3(busy) ->
-#     "BY";
-# fmt_status3(connected) ->
-#     "CD";
-# fmt_status3(connecting) ->
-#     "CG";
-# fmt_status3(listen) ->
-#     "LN";
-# fmt_status3(listening) ->
-#     "LG";
-# fmt_status3(open) ->
-#     "O";
-# fmt_status3(X) when is_atom(X) ->
-#     string:uppercase(atom_to_list(X)).

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   alias Phoenix.LiveDashboard.SystemInfo
 
-  @sort_by ~w(module recv_oct send_oct connected local_address foreign_address state type)
+  @sort_by ~w(send_oct recv_oct module connected local_address foreign_address state type)
 
   @impl true
   def mount(%{"node" => _} = params, session, socket) do
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
         <form phx-change="search" phx-submit="search" class="form-inline">
           <div class="form-row align-items-center">
             <div class="col-auto">
-              <input type="search" name="search" class="form-control form-control-sm" value="<%= @params.search %>" placeholder="Search by name or module" phx-debounce="300">
+              <input type="search" name="search" class="form-control form-control-sm" value="<%= @params.search %>" placeholder="Search by local or foreign address" phx-debounce="300">
             </div>
           </div>
         </form>
@@ -55,7 +55,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
             </div>
           </div>
           <div class="col-auto">
-            tables out of <%= @total %>
+            sockets out of <%= @total %>
           </div>
         </div>
       </form>
@@ -99,8 +99,8 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                     <td><%= format_bytes(socket[:send_oct]) %></td>
                     <td><%= format_bytes(socket[:recv_oct]) %></td>
                     <td><%= format_value(socket[:connected], &live_dashboard_path(@socket, &1, &2, &3, @params)) %></td>
-                    <td><%= format_address(socket[:local_address]) %></td>
-                    <td><%= format_address(socket[:foreign_address]) %></td>
+                    <td><%= socket[:local_address] %></td>
+                    <td><%= socket[:foreign_address] %></td>
                     <td><%= format_state(socket[:state]) %></td>
                     <td><%= socket[:type] %></td>
                   </tr>
@@ -136,20 +136,6 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   defp self_path(socket, node, params) do
     live_dashboard_path(socket, :sockets, node, [], params)
-  end
-
-  defp format_address({:error, :enotconn}), do: "*:*"
-  defp format_address({:error, _}), do: " "
-
-  defp format_address({:ok, address}) do
-    case address do
-      {{0, 0, 0, 0}, port} -> "*:#{port}"
-      {{0, 0, 0, 0, 0, 0, 0, 0}, port} -> "*:#{port}"
-      {{127, 0, 0, 1}, port} -> "localhost:#{port}"
-      {{0, 0, 0, 0, 0, 0, 0, 1}, port} -> "localhost:#{port}"
-      {:local, path} -> "local:#{path}"
-      {ip, port} -> "#{:inet.ntoa(ip)}:#{port}"
-    end
   end
 
   defp format_state(flags) do

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -4,7 +4,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   alias Phoenix.LiveDashboard.SystemInfo
 
-  @sort_by ~w(recv_oct send_oct local_address foreign_address)
+  @sort_by ~w(connected recv_oct send_oct local_address foreign_address)
 
   @tttt """
     port
@@ -97,13 +97,13 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                 <tr>
                   <th class="pl-4">Port ID</th>
                   <th>x</th>
-                  <th>x</th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :send_oct, "Sent") %>
                   </th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :recv_oct, "Received") %>
                   </th>
+                  <th>Owner</th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :local_address, "Local Address") %>
                   </th>
@@ -117,9 +117,9 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <tr phx-page-loading>
                     <td class="tabular-column-name pl-4"><%= socket[:id] %></td>
                     <td></td>
-                    <td></td>
-                    <td><%= socket[:send_oct] %></td>
-                    <td><%= socket[:recv_oct] %></td>
+                    <td><%= format_bytes(socket[:send_oct]) %></td>
+                    <td><%= format_bytes(socket[:recv_oct]) %></td>
+                    <td><%= format_value(socket[:connected], &live_dashboard_path(@socket, &1, &2, &3, @params)) %></td>
                     <td><%= socket[:local_address] %></td>
                     <td><%= socket[:foreign_address] %></td>
                   </tr>

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -76,7 +76,6 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :recv_oct, "Received") %>
                   </th>
-                  <th>Owner</th>
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :local_address, "Local Address") %>
                   </th>
@@ -89,6 +88,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                   <th>
                     <%= sort_link(@socket, @live_action, @menu, @params, :type, "Type") %>
                   </th>
+                  <th>Owner</th>
                 </tr>
               </thead>
               <tbody>
@@ -98,11 +98,11 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                     <td><%= socket[:module] %></td>
                     <td><%= format_bytes(socket[:send_oct]) %></td>
                     <td><%= format_bytes(socket[:recv_oct]) %></td>
-                    <td><%= format_value(socket[:connected], &live_dashboard_path(@socket, &1, &2, &3, @params)) %></td>
                     <td><%= socket[:local_address] %></td>
                     <td><%= socket[:foreign_address] %></td>
                     <td><%= format_state(socket[:state]) %></td>
                     <td><%= socket[:type] %></td>
+                    <td><%= format_value(socket[:connected], &live_dashboard_path(@socket, &1, &2, &3, @params)) %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -141,13 +141,13 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
   defp format_state(flags) do
     case Enum.sort(flags) do
       [:accepting | _] -> "ACCEPTING"
-      [:bound, :busy, :connected | _] -> "CONNECTED(BB)"
-      [:bound, :connected | _] -> "CONNECTED(B)"
+      [:bound, :busy, :connected | _] -> "BUSY"
+      [:bound, :connected | _] -> "CONNECTED"
       [:bound, :listen, :listening | _] -> "LISTENING"
       [:bound, :listen | _] -> "LISTEN"
       [:bound, :connecting | _] -> "CONNECTING"
       [:bound, :open] -> "BOUND"
-      [:connected, :open] -> "CONNECTED(O)"
+      [:connected, :open] -> "CONNECTED"
       [:open] -> "IDLE"
       [] -> "CLOSED"
       sorted -> inspect(sorted)

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -178,12 +178,13 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   defp format_address({:error, :enotconn}), do: "*:*"
   defp format_address({:error, _}), do: " "
+
   defp format_address({:ok, address}) do
     case address do
-      {{0,0,0,0}, port} -> "*:#{port}"
-      {{0,0,0,0,0,0,0,0}, port} -> "*:#{port}"
-      {{127,0,0,1}, port} -> "localhost:#{port}"
-      {{0,0,0,0,0,0,0,1}, port} -> "localhost:#{port}"
+      {{0, 0, 0, 0}, port} -> "*:#{port}"
+      {{0, 0, 0, 0, 0, 0, 0, 0}, port} -> "*:#{port}"
+      {{127, 0, 0, 1}, port} -> "localhost:#{port}"
+      {{0, 0, 0, 0, 0, 0, 0, 1}, port} -> "localhost:#{port}"
       {:local, path} -> "local:#{path}"
       {ip, port} -> "#{:inet.ntoa(ip)}:#{port}"
     end
@@ -191,17 +192,17 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
 
   defp format_state(flags) do
     case Enum.sort(flags) do
-      [:accepting | _]                  -> "ACCEPTING"
-      [:bound, :busy, :connected | _]   -> "CONNECTED(BB)"
-      [:bound, :connected | _]          -> "CONNECTED(B)"
+      [:accepting | _] -> "ACCEPTING"
+      [:bound, :busy, :connected | _] -> "CONNECTED(BB)"
+      [:bound, :connected | _] -> "CONNECTED(B)"
       [:bound, :listen, :listening | _] -> "LISTENING"
-      [:bound, :listen | _]             -> "LISTEN"
-      [:bound, :connecting | _]         -> "CONNECTING"
-      [:bound, :open]                   -> "BOUND"
-      [:connected, :open]               -> "CONNECTED(O)"
-      [:open]                           -> "IDLE"
-      []                                -> "CLOSED"
-      sorted                            -> inspect(sorted)
+      [:bound, :listen | _] -> "LISTEN"
+      [:bound, :connecting | _] -> "CONNECTING"
+      [:bound, :open] -> "BOUND"
+      [:connected, :open] -> "CONNECTED(O)"
+      [:open] -> "IDLE"
+      [] -> "CLOSED"
+      sorted -> inspect(sorted)
     end
   end
 end

--- a/lib/phoenix/live_dashboard/live/sockets_live.ex
+++ b/lib/phoenix/live_dashboard/live/sockets_live.ex
@@ -104,7 +104,7 @@ defmodule Phoenix.LiveDashboard.SocketsLive do
                 <%= for socket <- @sockets, port_num = encode_port(socket[:port]) do %>
                   <tr phx-click="show_info" phx-value-port="<%= port_num %>" phx-page-loading>
                     <td class="tabular-column-name pl-4"><pre><%= inspect(socket[:port]) %></pre></td>
-                    <td><%= socket[:module] %></td>
+                    <td><pre><%= socket[:module] %></pre></td>
                     <td><%= format_bytes(socket[:send_oct]) %></td>
                     <td><%= format_bytes(socket[:recv_oct]) %></td>
                     <td><%= socket[:local_address] %></td>

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -45,6 +45,7 @@ defmodule Phoenix.LiveDashboard.Router do
         live "/:node/ets", Phoenix.LiveDashboard.EtsLive, :ets, opts
         live "/:node/ets/:ref", Phoenix.LiveDashboard.EtsLive, :ets, opts
         live "/:node/sockets", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
+        live "/:node/sockets/:port", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
 
         live "/:node/request_logger",
              Phoenix.LiveDashboard.RequestLoggerLive,

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -44,6 +44,7 @@ defmodule Phoenix.LiveDashboard.Router do
         live "/:node/processes/:pid", Phoenix.LiveDashboard.ProcessesLive, :processes, opts
         live "/:node/ets", Phoenix.LiveDashboard.EtsLive, :ets, opts
         live "/:node/ets/:ref", Phoenix.LiveDashboard.EtsLive, :ets, opts
+        live "/:node/sockets", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
 
         live "/:node/request_logger",
              Phoenix.LiveDashboard.RequestLoggerLive,

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -285,7 +285,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
   end
 
   defp show_socket?(info) do
-    info[:name] in ['tcp_inet', 'udp_inet']
+    info[:name] in @inet_ports
   end
 
   ## Helpers

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -249,12 +249,15 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       :erlang.ports()
       |> Enum.filter(&show_socket?/1)
       |> Enum.map(fn port ->
-        {:id, id} = :erlang.port_info(port, :id)
+        info = :erlang.port_info(port)
         {:ok, stats} = :inet.getstat(port, [:send_oct, :recv_oct])
         local_address = format_address(:inet.sockname(port))
         foreign_address = format_address(:inet.peername(port))
+        IO.inspect(:prim_inet.getstatus(port))
 
-        Keyword.merge(stats, [id: id, local_address: local_address, foreign_address: foreign_address])
+        info
+        |> Keyword.merge(stats)
+        |> Keyword.merge([local_address: local_address, foreign_address: foreign_address])
       end)
       |> Enum.sort_by(fn x ->
         Keyword.fetch!(x, sort_by)

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -263,7 +263,10 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
   end
 
   def socket_info_callback(port, keys) do
-    port |> socket_info() |> Keyword.take(keys)
+    case socket_info(port) do
+      :error -> :error
+      info -> Keyword.take(info, keys)
+    end
   end
 
   defp socket_info(port) do

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -266,9 +266,11 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       end
       |> Enum.filter(&apply_socket_search(&1, search))
       |> Enum.sort_by(&Keyword.fetch!(&1, sort_by), sorter)
-      |> Enum.take(limit)
 
-    {sockets, length(sockets)}
+    count = length(sockets)
+    sockets = Enum.take(sockets, limit)
+
+    {sockets, count}
   end
 
   defp show_socket?(nil), do: false
@@ -281,8 +283,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     end
   end
 
-  defp apply_socket_search(nil, _), do: false
-  defp apply_socket_search(socket, nil), do: true
+  defp apply_socket_search(nil, _search), do: false
+  defp apply_socket_search(_socket, nil), do: true
 
   defp apply_socket_search(socket, search) do
     socket[:local_address] =~ search || socket[:foreign_address] =~ search

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -218,7 +218,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     {tables, count}
   end
 
-  defp info_ets(ref) do
+  defp ets_info(ref) do
     case :ets.info(ref) do
       :undefined -> nil
       info -> [name: inspect(info[:name])] ++ Keyword.delete(info, :name)
@@ -284,7 +284,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     {sockets, length(sockets)}
   end
 
-  defp show_socket?(port) do
+  defp show_socket?(info) do
     info[:name] in ['tcp_inet', 'udp_inet']
   end
 

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -246,7 +246,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     sorter = if sort_dir == :asc, do: &<=/2, else: &>=/2
 
     sockets =
-      :erlang.ports()
+      Port.list()
       |> Enum.map(fn port ->
         with info when not is_nil(info) <- Port.info(port),
              true <- show_socket?(info),

--- a/test/phoenix/live_dashboard/live/ports_live_test.exs
+++ b/test/phoenix/live_dashboard/live/ports_live_test.exs
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveDashboard.PortsInfoComponent do
+defmodule Phoenix.LiveDashboard.PortsLiveTest do
   use ExUnit.Case, async: true
 
   import Phoenix.ConnTest

--- a/test/phoenix/live_dashboard/live/sockets_live_test.exs
+++ b/test/phoenix/live_dashboard/live/sockets_live_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SocketsLiveTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest

--- a/test/phoenix/live_dashboard/live/sockets_live_test.exs
+++ b/test/phoenix/live_dashboard/live/sockets_live_test.exs
@@ -1,0 +1,106 @@
+defmodule Phoenix.LiveDashboard.SocketsLiveTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  @endpoint Phoenix.LiveDashboardTest.Endpoint
+
+  test "search" do
+    %{formatted_address: first_address, port: first_socket_port} = open_socket()
+    %{formatted_address: second_address} = open_socket()
+
+    {:ok, live, _} = live(build_conn(), sockets_path(50, "", :send_oct, :desc))
+    rendered = render(live)
+    assert rendered =~ first_address
+    assert rendered =~ second_address
+    assert rendered =~ "*:*"
+    assert rendered =~ "sockets out of 2"
+    assert rendered =~ sockets_href(50, "", :send_oct, :asc)
+
+    {:ok, live, _} = live(build_conn(), sockets_path(50, first_socket_port, :send_oct, :desc))
+
+    rendered = render(live)
+    assert rendered =~ first_address
+    refute rendered =~ second_address
+    assert rendered =~ "sockets out of 1"
+    assert rendered =~ sockets_href(50, first_socket_port, :send_oct, :asc)
+
+    {:ok, live, _} = live(build_conn(), sockets_path(50, "localhost", :send_oct, :desc))
+    rendered = render(live)
+    assert rendered =~ first_address
+    assert rendered =~ second_address
+    assert rendered =~ "sockets out of 2"
+    assert rendered =~ sockets_href(50, "localhost", :send_oct, :asc)
+  end
+
+  test "order sockets by local address port" do
+    %{formatted_address: address} = open_socket()
+    %{formatted_address: other_address} = open_socket()
+
+    [first_address, second_address] = Enum.sort([address, other_address])
+
+    {:ok, live, _} = live(build_conn(), sockets_path(50, "", :local_address, :asc))
+    rendered = render(live)
+    assert rendered =~ ~r/#{first_address}.*#{second_address}/s
+    assert rendered =~ sockets_href(50, "", :local_address, :desc)
+    refute rendered =~ sockets_href(50, "", :local_address, :asc)
+
+    rendered =
+      render_patch(
+        live,
+        "/dashboard/nonode@nohost/sockets?limit=50&sort_dir=desc&sort_by=local_address"
+      )
+
+    assert rendered =~ ~r/#{second_address}.*#{first_address}/s
+    refute rendered =~ ~r/#{first_address}.*#{second_address}/s
+    assert rendered =~ sockets_href(50, "", :local_address, :asc)
+    refute rendered =~ sockets_href(50, "", :local_address, :desc)
+
+    rendered =
+      render_patch(
+        live,
+        "/dashboard/nonode@nohost/sockets?limit=50&sort_dir=asc&sort_by=local_address"
+      )
+
+    assert rendered =~ ~r/#{first_address}.*#{second_address}/s
+    refute rendered =~ ~r/#{second_address}.*#{first_address}/s
+    assert rendered =~ sockets_href(50, "", :local_address, :desc)
+    refute rendered =~ sockets_href(50, "", :local_address, :asc)
+  end
+
+  test "shows socket info modal" do
+    %{socket: socket, formatted_address: address} = open_socket()
+
+    {:ok, live, _} = live(build_conn(), socket_info_path(socket, 50, :send_oct, :asc))
+    rendered = render(live)
+    assert rendered =~ sockets_href(50, "", :send_oct, :asc)
+
+    assert rendered =~ "modal-content"
+    assert rendered =~ ~r/Local Address.*#{address}/
+
+    refute live |> element("#modal .close") |> render_click() =~ "modal"
+    return_path = sockets_path(50, "", :send_oct, :asc)
+    assert_patch(live, return_path)
+  end
+
+  defp sockets_href(limit, search, sort_by, sort_dir) do
+    ~s|href="#{Plug.HTML.html_escape_to_iodata(sockets_path(limit, search, sort_by, sort_dir))}"|
+  end
+
+  defp socket_info_path(port, limit, sort_by, sort_dir) do
+    "/dashboard/nonode%40nohost/sockets/#{Phoenix.LiveDashboard.ViewHelpers.encode_port(port)}?" <>
+      "limit=#{limit}&sort_by=#{sort_by}&sort_dir=#{sort_dir}"
+  end
+
+  defp sockets_path(limit, search, sort_by, sort_dir) do
+    "/dashboard/nonode%40nohost/sockets?" <>
+      "limit=#{limit}&search=#{search}&sort_by=#{sort_by}&sort_dir=#{sort_dir}"
+  end
+
+  defp open_socket() do
+    with {:ok, socket} <- :gen_tcp.listen(0, ip: {127, 0, 0, 1}),
+         {:ok, {_, port}} <- :inet.sockname(socket) do
+      %{formatted_address: "localhost:#{port}", socket: socket, ip: "localhost", port: port}
+    end
+  end
+end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -76,34 +76,28 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
 
   describe "sockets" do
     test "all with limit" do
-      open_socket(fn ->
-        open_socket(fn ->
-          {sockets, count} = SystemInfo.fetch_sockets(node(), "", :input, :asc, 100)
-          assert Enum.count(sockets) == count
-          {sockets, count} = SystemInfo.fetch_sockets(node(), "", :input, :asc, 1)
-          assert Enum.count(sockets) == 1
-          assert count > 1
-        end)
-      end)
+      open_socket()
+      open_socket()
+
+      {sockets, count} = SystemInfo.fetch_sockets(node(), "", :input, :asc, 100)
+      assert Enum.count(sockets) == count
+      {sockets, count} = SystemInfo.fetch_sockets(node(), "", :input, :asc, 1)
+      assert Enum.count(sockets) == 1
+      assert count > 1
     end
 
     test "all with search" do
-      open_socket(fn ->
-        {[socket], _count} = SystemInfo.fetch_sockets(node(), "*:*", :input, :asc, 100)
-        assert socket[:foreign_address] == "*:*"
-        {sockets, _count} = SystemInfo.fetch_sockets(node(), "impossible", :input, :asc, 100)
-        assert Enum.empty?(sockets)
-      end)
+      open_socket()
+
+      {[socket], _count} = SystemInfo.fetch_sockets(node(), "*:*", :input, :asc, 100)
+      assert socket[:foreign_address] == "*:*"
+      {sockets, _count} = SystemInfo.fetch_sockets(node(), "impossible", :input, :asc, 100)
+      assert Enum.empty?(sockets)
     end
   end
 
-  defp open_socket(fun) do
-    {:ok, socket} = :gen_tcp.listen(0, [])
-
-    try do
-      fun.()
-    after
-      :gen_tcp.close(socket)
-    end
+  defp open_socket() do
+    {:ok, socket} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
+    socket
   end
 end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SystemInfoTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Phoenix.LiveDashboard.SystemInfo
 
   describe "processes" do

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SystemInfoTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias Phoenix.LiveDashboard.SystemInfo
 
   describe "processes" do


### PR DESCRIPTION
This address #43 

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/3228071/79871680-fe45f080-83e4-11ea-82b9-44d55dc4dac1.png">

This is a work in progress PR, early feedback is welcome 🤗 

We (@maltoe and I) tried to follow the `:inet.i()` implementation

TODO:
- [x] Add tests

Questions:
- The table shows all the fields that are shown by `:inet.i()`, therefore we thought that the "show" view for a single socket was unnecessary and we didn't implement it. What do you think?
- We slightly simplify the formatting of the socket state. The original implementation is way more verbose (look at [`inet:fmt_status3`](https://github.com/erlang/otp/blob/1b27bfc23c0ab84952db89c0667e68253a91dcce/lib/kernel/src/inet.erl#L1680)), we can, of course, update our implementation if needed.
- The search is limited to the local and foreign address, is it ok?