### PR TITLE
Fix html display for sort icons

### DIFF
--- a/lib/phoenix/live_dashboard/helpers/table_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/table_helpers.ex
@@ -50,19 +50,21 @@ defmodule Phoenix.LiveDashboard.TableHelpers do
   end
 
   defp sort_link_icon(:asc) do
-    """
-    <div class="dash-table-icon">
-      <span class="icon-sort icon-asc"></span>
-    </div>
-    """
+    {:safe,
+     """
+     <div class="dash-table-icon">
+       <span class="icon-sort icon-asc"></span>
+     </div>
+     """}
   end
 
   defp sort_link_icon(:desc) do
-    """
-    <div class="dash-table-icon">
-      <span class="icon-sort icon-desc"></span>
-    </div>
-    """
+    {:safe,
+     """
+     <div class="dash-table-icon">
+       <span class="icon-sort icon-desc"></span>
+     </div>
+     """}
   end
 
   defp opposite_sort_dir(%{sort_dir: :desc}), do: :asc


### PR DESCRIPTION
Change https://github.com/phoenixframework/phoenix_live_dashboard/commit/13b7fe98a43198439d59b7f3b94f0282d145ddb2#diff-82b0121ba413c67ae89099a25fd58d60L54 will cause escaped HTML to be displayed:

![image](https://user-images.githubusercontent.com/1810732/80024803-e69f6280-84df-11ea-9e90-c5a5a8030f6c.png)

To avoid importing Phoenix.HTML for the E sygil I propose just wrapping this part in the `:safe` tuple
