### PR TITLE
Applications tab

### DIFF
--- a/lib/phoenix/live_dashboard/helpers/table_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/table_helpers.ex
@@ -24,6 +24,7 @@ defmodule Phoenix.LiveDashboard.TableHelpers do
   end
 
   def limit_options(), do: @limit
+
   def sort_link(socket, live_action, menu, params, sort_by, link_name) do
     case params do
       %{sort_by: ^sort_by, sort_dir: sort_dir} ->

--- a/lib/phoenix/live_dashboard/helpers/table_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/table_helpers.ex
@@ -18,12 +18,23 @@ defmodule Phoenix.LiveDashboard.TableHelpers do
     assign(socket, :params, %{sort_by: sort_by, sort_dir: sort_dir, limit: limit, search: search})
   end
 
-  defp get_in_or_first(params, key, valid) do
+  def get_in_or_first(params, key, valid) do
     value = params[key]
     if value in valid, do: value, else: hd(valid)
   end
 
   def limit_options(), do: @limit
+
+
+  def filter_tab(socket, live_action, menu, params, filter, link_name) do
+    current_filter = Map.get(params, :filter, :started)
+    params = Map.put(params, :filter, filter)
+
+    class = if filter == current_filter, do: "nav-link active", else: "nav-link"
+
+    link_name 
+    |> live_patch(to: live_dashboard_path(socket, live_action, menu.node, [], params), class: class)
+  end
 
   def sort_link(socket, live_action, menu, params, sort_by, link_name) do
     case params do

--- a/lib/phoenix/live_dashboard/helpers/table_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/table_helpers.ex
@@ -18,26 +18,12 @@ defmodule Phoenix.LiveDashboard.TableHelpers do
     assign(socket, :params, %{sort_by: sort_by, sort_dir: sort_dir, limit: limit, search: search})
   end
 
-  def get_in_or_first(params, key, valid) do
+  defp get_in_or_first(params, key, valid) do
     value = params[key]
     if value in valid, do: value, else: hd(valid)
   end
 
   def limit_options(), do: @limit
-
-  def filter_tab(socket, live_action, menu, params, filter, link_name) do
-    current_filter = Map.get(params, :filter, :started)
-    params = Map.put(params, :filter, filter)
-
-    class = if filter == current_filter, do: "nav-link active", else: "nav-link"
-
-    link_name
-    |> live_patch(
-      to: live_dashboard_path(socket, live_action, menu.node, [], params),
-      class: class
-    )
-  end
-
   def sort_link(socket, live_action, menu, params, sort_by, link_name) do
     case params do
       %{sort_by: ^sort_by, sort_dir: sort_dir} ->

--- a/lib/phoenix/live_dashboard/helpers/table_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/table_helpers.ex
@@ -25,15 +25,17 @@ defmodule Phoenix.LiveDashboard.TableHelpers do
 
   def limit_options(), do: @limit
 
-
   def filter_tab(socket, live_action, menu, params, filter, link_name) do
     current_filter = Map.get(params, :filter, :started)
     params = Map.put(params, :filter, filter)
 
     class = if filter == current_filter, do: "nav-link active", else: "nav-link"
 
-    link_name 
-    |> live_patch(to: live_dashboard_path(socket, live_action, menu.node, [], params), class: class)
+    link_name
+    |> live_patch(
+      to: live_dashboard_path(socket, live_action, menu.node, [], params),
+      class: class
+    )
   end
 
   def sort_link(socket, live_action, menu, params, sort_by, link_name) do

--- a/lib/phoenix/live_dashboard/live/applications_live.ex
+++ b/lib/phoenix/live_dashboard/live/applications_live.ex
@@ -8,17 +8,17 @@ defmodule Phoenix.LiveDashboard.ApplicationsLive do
 
   @impl true
   def mount(%{"node" => _} = params, session, socket) do
-    {:ok, 
-    socket
-    |> assign_defaults(params, session, true)}
+    {:ok,
+     socket
+     |> assign_defaults(params, session, true)}
   end
 
   @impl true
   def handle_params(params, _url, socket) do
-    {:noreply, 
-        socket
-        |> assign_params(params, @sort_by)
-        |> fetch_applications()}
+    {:noreply,
+     socket
+     |> assign_params(params, @sort_by)
+     |> fetch_applications()}
   end
 
   defp fetch_applications(%{assigns: %{params: params, menu: menu}} = socket) do
@@ -93,10 +93,12 @@ defmodule Phoenix.LiveDashboard.ApplicationsLive do
     </div>
     """
   end
+
   @impl true
   def handle_info({:node_redirect, node}, socket) do
     {:noreply, push_redirect(socket, to: self_path(socket, node, socket.assigns.params))}
   end
+
   def handle_info(:refresh, socket) do
     {:noreply, socket}
   end
@@ -112,9 +114,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsLive do
     {:noreply, push_patch(socket, to: self_path(socket, menu.node, %{params | limit: limit}))}
   end
 
-
   defp self_path(socket, node, params) do
     live_dashboard_path(socket, :applications, node, [], params)
   end
-
 end

--- a/lib/phoenix/live_dashboard/live/applications_live.ex
+++ b/lib/phoenix/live_dashboard/live/applications_live.ex
@@ -1,0 +1,106 @@
+defmodule Phoenix.LiveDashboard.ApplicationsLive do
+  use Phoenix.LiveDashboard.Web, :live_view
+  import Phoenix.LiveDashboard.TableHelpers
+
+  alias Phoenix.LiveDashboard.SystemInfo
+
+  @sort_by ~w(output input)
+
+  @impl true
+  def mount(%{"node" => _} = params, session, socket) do
+    {:ok, assign_defaults(socket, params, session, true)}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply,
+     socket
+     |> assign_params(params, @sort_by)
+     |> fetch_apps()}
+  end
+
+  defp fetch_apps(socket) do
+
+    apps = SystemInfo.fetch_apps(socket.assigns.menu.node)
+
+    assign(socket, apps: apps)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="tabular-page">
+      <h5 class="card-title">Applications</h5>
+
+      <div class="tabular-search">
+        <form phx-change="search" phx-submit="search" class="form-inline">
+          <div class="form-row align-items-center">
+            <div class="col-auto">
+              <input type="search" name="search" class="form-control form-control-sm" value="<%= @params.search %>" placeholder="Search by name or port" phx-debounce="300">
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <form phx-change="select_limit" class="form-inline">
+        <div class="form-row align-items-center">
+          <div class="col-auto">Showing at most</div>
+          <div class="col-auto">
+            <div class="input-group input-group-sm">
+              <select name="limit" class="custom-select" id="limit-select">
+                <%= options_for_select(limit_options(), @params.limit) %>
+              </select>
+            </div>
+          </div>
+          <div class="col-auto">
+            applications out of <%= Enum.count(@apps) %>
+          </div>
+        </div>
+      </form>
+
+      <div class="card table-card mb-4 mt-4">
+        <div class="card-body p-0">
+          <div class="dash-table-wrapper">
+            <table class="table table-hover mt-0 dash-table clickable-rows">
+              <thead>
+                <tr>
+                  <th class="pl-4">Application</th>
+                  <th>Description</th>
+                  <th>Version</td>
+                </tr>
+              </thead>
+              <tbody>
+                <%= for {name, desc, ver} <- @apps do %>
+                  <tr phx-page-loading>
+                    <td><%= name %></td>
+                    <td><%= desc %></td>
+                    <td><%= ver %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+  @impl true
+  def handle_info({:node_redirect, node}, socket) do
+    {:noreply, push_redirect(socket, to: self_path(socket, node, socket.assigns.params))}
+  end
+  def handle_info({:refresh, _node}, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    %{menu: menu, params: params} = socket.assigns
+    {:noreply, push_patch(socket, to: self_path(socket, menu.node, %{params | search: search}))}
+  end
+
+  defp self_path(socket, node, params) do
+    live_dashboard_path(socket, :applications, node, [], params)
+  end
+
+end

--- a/lib/phoenix/live_dashboard/live/menu_live.ex
+++ b/lib/phoenix/live_dashboard/live/menu_live.ex
@@ -27,6 +27,7 @@ defmodule Phoenix.LiveDashboard.MenuLive do
       <%= maybe_active_live_redirect @socket, @menu, "Ports", :ports, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Sockets", :sockets, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "ETS", :ets, @node %>
+      <%= maybe_active_live_redirect @socket, @menu, "Applications", :applications, @node %>
     </nav>
 
     <form id="node-selection" phx-change="select_node" class="d-inline">

--- a/lib/phoenix/live_dashboard/live/menu_live.ex
+++ b/lib/phoenix/live_dashboard/live/menu_live.ex
@@ -23,11 +23,11 @@ defmodule Phoenix.LiveDashboard.MenuLive do
       <%= maybe_active_live_redirect @socket, @menu, "Home", :home, @node %>
       <%= maybe_enabled_live_redirect @socket, @menu, "Metrics", :metrics, @node %>
       <%= maybe_enabled_live_redirect @socket, @menu, "Request Logger", :request_logger, @node %>
+      <%= maybe_active_live_redirect @socket, @menu, "Applications", :applications, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Processes", :processes, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Ports", :ports, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "Sockets", :sockets, @node %>
       <%= maybe_active_live_redirect @socket, @menu, "ETS", :ets, @node %>
-      <%= maybe_active_live_redirect @socket, @menu, "Applications", :applications, @node %>
     </nav>
 
     <form id="node-selection" phx-change="select_node" class="d-inline">

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -48,11 +48,6 @@ defmodule Phoenix.LiveDashboard.Router do
         live "/:node/sockets/:port", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
         live "/:node/applications", Phoenix.LiveDashboard.ApplicationsLive, :applications, opts
 
-        live "/:node/applications/:app",
-             Phoenix.LiveDashboard.ApplicationsLive,
-             :applications,
-             opts
-
         live "/:node/request_logger",
              Phoenix.LiveDashboard.RequestLoggerLive,
              :request_logger,

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -47,7 +47,11 @@ defmodule Phoenix.LiveDashboard.Router do
         live "/:node/sockets", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
         live "/:node/sockets/:port", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
         live "/:node/applications", Phoenix.LiveDashboard.ApplicationsLive, :applications, opts
-        live "/:node/applications/:app", Phoenix.LiveDashboard.ApplicationsLive, :applications, opts
+
+        live "/:node/applications/:app",
+             Phoenix.LiveDashboard.ApplicationsLive,
+             :applications,
+             opts
 
         live "/:node/request_logger",
              Phoenix.LiveDashboard.RequestLoggerLive,

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -46,6 +46,8 @@ defmodule Phoenix.LiveDashboard.Router do
         live "/:node/ets/:ref", Phoenix.LiveDashboard.EtsLive, :ets, opts
         live "/:node/sockets", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
         live "/:node/sockets/:port", Phoenix.LiveDashboard.SocketsLive, :sockets, opts
+        live "/:node/applications", Phoenix.LiveDashboard.ApplicationsLive, :applications, opts
+        live "/:node/applications/:app", Phoenix.LiveDashboard.ApplicationsLive, :applications, opts
 
         live "/:node/request_logger",
              Phoenix.LiveDashboard.RequestLoggerLive,

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -176,6 +176,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
     name =~ search or desc =~ search or version =~ search
   end
+
   def started_apps_set() do
     Application.started_applications()
     |> Enum.map(fn {name, _, _} -> name end)
@@ -186,22 +187,25 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     multiplier = sort_dir_multipler(sort_dir)
     started_apps_set = started_apps_set()
 
-    loaded_apps = 
+    loaded_apps =
       Application.loaded_applications()
-      |> Enum.map(fn {name, desc, ver} -> 
-        is_started? =  MapSet.member?(started_apps_set, name)
+      |> Enum.map(fn {name, desc, ver} ->
+        is_started? = MapSet.member?(started_apps_set, name)
         {name, desc, ver, is_started?}
-      end) 
+      end)
 
     apps =
       for application <- loaded_apps, show_application?(application, search) do
         sorter = elem(application, %{name: 0, version: 2}[sort_by])
-        sorter = cond do
-          # sorts only on first character
-          is_atom(sorter) -> hd(Atom.to_charlist(sorter)) * multiplier
-          is_list(sorter) -> hd(sorter) * multiplier
-          true -> 0
-        end
+
+        sorter =
+          cond do
+            # sorts only on first character
+            is_atom(sorter) -> hd(Atom.to_charlist(sorter)) * multiplier
+            is_list(sorter) -> hd(sorter) * multiplier
+            true -> 0
+          end
+
         {sorter, application}
       end
 

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -32,6 +32,10 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     :rpc.call(node, __MODULE__, :ports_callback, [search, sort_by, sort_dir, limit])
   end
 
+  def fetch_apps(node) do
+    :rpc.call(node, __MODULE__, :applications_info_callback, [])
+  end
+
   def fetch_port_info(port, keys) do
     :rpc.call(node(port), __MODULE__, :port_info_callback, [port, keys])
   end
@@ -157,6 +161,13 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       [_ | _] = info -> {:ok, info}
       nil -> :error
     end
+  end
+
+  ## Ports callbacks
+  #
+  def applications_info_callback() do
+    #Application.loaded_applications
+    Application.started_applications
   end
 
   ## Ports callbacks

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -189,6 +189,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       for application <- application_getter_fun.(), show_application?(application, search) do
         sorter = elem(application, %{name: 0, version: 2}[sort_by])
         sorter = cond do
+          # sorts only on first character
           is_atom(sorter) -> hd(Atom.to_charlist(sorter)) * multiplier
           is_list(sorter) -> hd(sorter) * multiplier
           true -> 0

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -69,6 +69,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
     count_loaded =  rendered |> :binary.matches("</tr>") |> length()
 
     assert count_loaded == count_started + 1
+    Application.unload(:sasl)
   end
 
   defp applications_href(limit, search, sort_by, sort_dir, filter) do

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -1,4 +1,4 @@
-defmodule Phoenix.LiveDashboard.PortsLiveTest do
+defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
   use ExUnit.Case, async: true
 
   import Phoenix.ConnTest

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -8,9 +8,6 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
   test "shows applications with limit" do
     {:ok, _live, rendered} = live(build_conn(), "/dashboard/nonode@nohost/applications")
     assert rendered |> :binary.matches("</tr>") |> length() <= 100
-
-    #rendered = render_patch(live, "/dashboard/nonode@nohost/applications?limit=5")
-    #assert rendered |> :binary.matches("</tr>") |> length() ==  4
   end
 
   test "search" do
@@ -38,7 +35,6 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
   end
 
   test "not started applications have different status in table" do
-    #Load only dont start
     {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc))
     rendered = render(live)
 
@@ -59,7 +55,9 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
   end
 
   defp applications_href(limit, search, sort_by, sort_dir) do
-    ~s|href="#{Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))}"|
+    ~s|href="#{
+      Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))
+    }"|
   end
 
   defp applications_path(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -37,7 +37,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
     assert rendered =~ applications_href(50, "kernel", :name, :asc)
   end
 
-  test "12" do
+  test "not started applications have different status in table" do
     #Load only dont start
     {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc))
     rendered = render(live)

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -1,0 +1,87 @@
+defmodule Phoenix.LiveDashboard.PortsLiveTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  @endpoint Phoenix.LiveDashboardTest.Endpoint
+
+  test "shows applications with limit" do
+    {:ok, _live, rendered} = live(build_conn(), "/dashboard/nonode@nohost/applications")
+    assert rendered |> :binary.matches("</tr>") |> length() <= 100
+
+    #rendered = render_patch(live, "/dashboard/nonode@nohost/applications?limit=5")
+    #assert rendered |> :binary.matches("</tr>") |> length() ==  4
+  end
+
+  test "search" do
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :name, :desc, :started))
+    rendered = render(live)
+    assert rendered =~ "ex_unit"
+    assert rendered =~ "kernel"
+    assert rendered =~ "applications out of 27"
+    assert rendered =~ applications_href(50, "", :name, :asc, :started)
+
+    {:ok, live, _} = live(build_conn(), applications_path(50, "unit", :name, :desc, :started))
+
+    rendered = render(live)
+    assert rendered =~ "ex_unit"
+    refute rendered =~ "kernel"
+    assert rendered =~ "applications out of 1"
+    assert rendered =~ applications_href(50, "unit", :name, :asc, :started)
+
+    {:ok, live, _} = live(build_conn(), applications_path(50, "kernel", :name, :desc, :started))
+    rendered = render(live)
+    assert rendered =~ "kernel"
+    refute rendered =~ "ex_unit"
+    assert rendered =~ "applications out of 1"
+    assert rendered =~ applications_href(50, "kernel", :name, :asc, :started)
+  end
+
+  test "active tab started or loaded" do
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :started))
+    rendered = render(live)
+    assert rendered =~ tab_link(50, "", :version, :asc, :started, "Started")
+    refute rendered =~ tab_link(50, "", :version, :asc, :loaded, "Loaded")
+
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :loaded))
+    rendered = render(live)
+    refute rendered =~ tab_link(50, "", :version, :asc, :started, "Started")
+    assert rendered =~ tab_link(50, "", :version, :asc, :loaded, "Loaded")
+  end
+
+  test "different count in started and loaded tab" do
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :started))
+    rendered = render(live)
+    count_started =  rendered |> :binary.matches("</tr>") |> length()
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :loaded))
+    rendered = render(live)
+    count_loaded =  rendered |> :binary.matches("</tr>") |> length()
+
+    assert count_loaded == count_started
+
+    #Load only dont start
+    Application.load(:sasl)
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :started))
+    rendered = render(live)
+    count_started =  rendered |> :binary.matches("</tr>") |> length()
+    {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc, :loaded))
+    rendered = render(live)
+    count_loaded =  rendered |> :binary.matches("</tr>") |> length()
+
+    assert count_loaded == count_started + 1
+  end
+
+  defp applications_href(limit, search, sort_by, sort_dir, filter) do
+    ~s|href="#{Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir, filter))}"|
+  end
+
+  defp applications_path(limit, search, sort_by, sort_dir, filter) do
+    "/dashboard/nonode%40nohost/applications?" <>
+      "filter=#{filter}&limit=#{limit}&search=#{search}&sort_by=#{sort_by}&sort_dir=#{sort_dir}"
+  end
+
+  defp tab_link(limit, search, sort_by, sort_dir, filter, link_text) do
+    href = applications_href(limit, search, sort_by, sort_dir, filter)
+    ~s|<a class="nav-link active" data-phx-link="patch" data-phx-link-state="push" #{href}>#{link_text}</a>|
+  end
+end

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -40,18 +40,18 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
 
     refute rendered =~ ~s|<td>sasl|
 
-    Application.load(:sasl)
+    Application.load(:ssh)
     {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc))
     rendered = render(live)
-    assert rendered =~ ~s|<tr class="text-muted"><td>sasl|
-    refute rendered =~ ~s|<tr class=""><td>sasl|
+    assert rendered =~ ~s|<tr class="text-muted"><td>ssh|
+    refute rendered =~ ~s|<tr class=""><td>ssh|
 
-    Application.start(:sasl)
+    Application.start(:ssh)
     {:ok, live, _} = live(build_conn(), applications_path(50, "", :version, :asc))
     rendered = render(live)
-    refute rendered =~ ~s|<tr class="text-muted"><td>sasl|
-    assert rendered =~ ~s|<tr class=""><td>sasl|
-    Application.unload(:sasl)
+    refute rendered =~ ~s|<tr class="text-muted"><td>ssh|
+    assert rendered =~ ~s|<tr class=""><td>ssh|
+    Application.unload(:ssh)
   end
 
   defp applications_href(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/live/applications_live_test.exs
+++ b/test/phoenix/live_dashboard/live/applications_live_test.exs
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsLiveTest do
     rendered = render(live)
     assert rendered =~ "ex_unit"
     assert rendered =~ "kernel"
-    assert rendered =~ "applications out of 27"
+    refute rendered =~ "applications out of 1"
     assert rendered =~ applications_href(50, "", :name, :asc, :started)
 
     {:ok, live, _} = live(build_conn(), applications_path(50, "unit", :name, :desc, :started))

--- a/test/phoenix/live_dashboard/live/ports_live_test.exs
+++ b/test/phoenix/live_dashboard/live/ports_live_test.exs
@@ -14,57 +14,58 @@ defmodule Phoenix.LiveDashboard.PortsLiveTest do
   end
 
   test "search" do
-    Port.open({:spawn, "sleep 15"}, [:binary])
-    Port.open({:spawn, "cat"}, [:binary])
+    Port.open({:spawn, "sleep 5"}, [:binary])
 
     {:ok, live, _} = live(build_conn(), ports_path(50, "", :input, :desc))
     rendered = render(live)
-    assert rendered =~ "cat"
+    assert rendered =~ "forker"
     assert rendered =~ "sleep"
-    assert rendered =~ "ports out of 5"
+    assert rendered =~ "ports out of 4"
     assert rendered =~ ports_href(50, "", :input, :asc)
 
     {:ok, live, _} = live(build_conn(), ports_path(50, "sleep", :input, :desc))
 
     rendered = render(live)
     assert rendered =~ "sleep"
-    refute rendered =~ "cat"
+    refute rendered =~ "forker"
     assert rendered =~ "ports out of 1"
     assert rendered =~ ports_href(50, "sleep", :input, :asc)
+    refute rendered =~ ports_href(50, "forker", :input, :asc)
 
-    {:ok, live, _} = live(build_conn(), ports_path(50, "cat", :input, :desc))
+    {:ok, live, _} = live(build_conn(), ports_path(50, "forker", :input, :desc))
     rendered = render(live)
-    assert rendered =~ "cat"
+    assert rendered =~ "forker"
     refute rendered =~ "sleep"
     assert rendered =~ "ports out of 1"
-    assert rendered =~ ports_href(50, "cat", :input, :asc)
+    assert rendered =~ ports_href(50, "forker", :input, :asc)
+    refute rendered =~ ports_href(50, "sleep", :input, :asc)
   end
 
   test "order ports by output" do
     # We got already forker running as #Port<0.0>
     # And we need something thats on all systems and stays attached to the port
-    cat = Port.open({:spawn, "cat"}, [:binary])
-    send(cat, {self(), {:command, "increase output"}})
+    sleep = Port.open({:spawn, "sleep 5"}, [:binary])
+    send(sleep, {self(), {:command, "increase output"}})
 
     {:ok, live, _} = live(build_conn(), ports_path(50, "", :output, :asc))
     rendered = render(live)
-    assert rendered =~ ~r/forker.*cat/s
+    assert rendered =~ ~r/forker.*sleep/s
     assert rendered =~ ports_href(50, "", :output, :desc)
     refute rendered =~ ports_href(50, "", :output, :asc)
 
     rendered =
       render_patch(live, "/dashboard/nonode@nohost/ports?limit=50&sort_dir=desc&sort_by=output")
 
-    assert rendered =~ ~r/cat.*forker/s
-    refute rendered =~ ~r/forker.*cat/s
+    assert rendered =~ ~r/sleep.*forker/s
+    refute rendered =~ ~r/forker.*sleep/s
     assert rendered =~ ports_href(50, "", :output, :asc)
     refute rendered =~ ports_href(50, "", :output, :desc)
 
     rendered =
       render_patch(live, "/dashboard/nonode@nohost/ports?limit=50&sort_dir=asc&sort_by=output")
 
-    assert rendered =~ ~r/forker.*cat/s
-    refute rendered =~ ~r/cat.*forker/s
+    assert rendered =~ ~r/forker.*sleep/s
+    refute rendered =~ ~r/sleep.*forker/s
     assert rendered =~ ports_href(50, "", :output, :desc)
     refute rendered =~ ports_href(50, "", :output, :asc)
   end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -96,6 +96,33 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     end
   end
 
+  describe "applications" do
+    test "all with limit" do
+
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      assert Enum.count(applications) == count
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 1, :started)
+      assert Enum.count(applications) == 1
+      assert count > 1
+    end
+
+    test "all with search" do
+
+      {[applications], _count} = SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100, :started)
+      assert elem(applications, 0) == :ex_unit
+      {applications, _count} = SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100, :started)
+      assert Enum.empty?(applications)
+    end
+
+    test "started or loaded" do
+
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      IO.inspect(count)
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
+      IO.inspect(count)
+    end
+  end
+
   defp open_socket() do
     {:ok, socket} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
     socket

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SystemInfoTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias Phoenix.LiveDashboard.SystemInfo
 
   describe "processes" do
@@ -99,42 +99,35 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
   describe "applications" do
     test "all with limit" do
 
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
       assert Enum.count(applications) == count
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 1, :started)
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 1)
       assert Enum.count(applications) == 1
       assert count > 1
     end
 
     test "all with search" do
 
-      {[applications], _count} = SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100, :started)
+      {[applications], _count} = SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100)
       assert elem(applications, 0) == :ex_unit
-      {applications, _count} = SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100, :started)
+      {applications, _count} = SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100)
       assert Enum.empty?(applications)
     end
 
-    test "started or loaded" do
-
-      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
-      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
-
-      assert count_loaded == count_started
-      assert Enum.count(started) == Enum.count(loaded)
-
+    test "test started status" do
       Application.load(:sasl) #Load only dont start
-      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
-      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
 
-      assert count_loaded == count_started + 1
-      assert Enum.count(loaded) == Enum.count(started) + 1
+      {applications, _count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
+
+      Enum.each(applications, fn {name, _, _, is_started?} -> 
+      if name == :sasl do
+        assert is_started? == false
+      else
+        assert is_started? == true
+      end
+      end)
 
       Application.unload(:sasl) #Load only dont start
-      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
-      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
-
-      assert count_loaded == count_started
-      assert Enum.count(started) == Enum.count(loaded)
     end
   end
 

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -99,18 +99,22 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
   describe "applications" do
     test "all with limit" do
 
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
+      {applications, count} =
+        SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
       assert Enum.count(applications) == count
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 1)
+      {applications, count} =
+        SystemInfo.fetch_applications(node(), "", :name, :asc, 1)
       assert Enum.count(applications) == 1
       assert count > 1
     end
 
     test "all with search" do
 
-      {[applications], _count} = SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100)
+      {[applications], _count} =
+        SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100)
       assert elem(applications, 0) == :ex_unit
-      {applications, _count} = SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100)
+      {applications, _count} =
+        SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100)
       assert Enum.empty?(applications)
     end
   end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -98,23 +98,22 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
 
   describe "applications" do
     test "all with limit" do
-
-      {applications, count} =
-        SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
       assert Enum.count(applications) == count
-      {applications, count} =
-        SystemInfo.fetch_applications(node(), "", :name, :asc, 1)
+      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 1)
       assert Enum.count(applications) == 1
       assert count > 1
     end
 
     test "all with search" do
-
       {[applications], _count} =
         SystemInfo.fetch_applications(node(), "ex_unit", :name, :asc, 100)
+
       assert elem(applications, 0) == :ex_unit
+
       {applications, _count} =
         SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100)
+
       assert Enum.empty?(applications)
     end
   end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SystemInfoTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Phoenix.LiveDashboard.SystemInfo
 
   describe "processes" do

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -113,22 +113,6 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       {applications, _count} = SystemInfo.fetch_applications(node(), "impossible", :name, :asc, 100)
       assert Enum.empty?(applications)
     end
-
-    test "test started status" do
-      Application.load(:sasl) #Load only dont start
-
-      {applications, _count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100)
-
-      Enum.each(applications, fn {name, _, _, is_started?} -> 
-      if name == :sasl do
-        assert is_started? == false
-      else
-        assert is_started? == true
-      end
-      end)
-
-      Application.unload(:sasl) #Load only dont start
-    end
   end
 
   defp open_socket() do

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -116,10 +116,25 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
 
     test "started or loaded" do
 
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
-      IO.inspect(count)
-      {applications, count} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
-      IO.inspect(count)
+      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
+
+      assert count_loaded == count_started
+      assert Enum.count(started) == Enum.count(loaded)
+
+      Application.load(:sasl) #Load only dont start
+      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
+
+      assert count_loaded == count_started + 1
+      assert Enum.count(loaded) == Enum.count(started) + 1
+
+      Application.unload(:sasl) #Load only dont start
+      {started, count_started} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :started)
+      {loaded, count_loaded} = SystemInfo.fetch_applications(node(), "", :name, :asc, 100, :loaded)
+
+      assert count_loaded == count_started
+      assert Enum.count(started) == Enum.count(loaded)
     end
   end
 


### PR DESCRIPTION
New day new tab (with live sub tabs)
I have some race conditions in tests - I created 2 tabs - 1 shows loaded applications and the other started. But when starting applications in tests I think its sometimes too slow to catch it - I need some help.
Another problem is sorting - current sorting is by number but I need to sort by string - I solved it temporary using only the first letter. Same with versions - but I dont think that it makes sense to sort by version at all, Ill probably remove it.
![image](https://user-images.githubusercontent.com/904179/80280119-014d2380-86fa-11ea-8097-861335a83a0c.png)
