### PR TITLE
Add an alias for development `mix dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ Then you should be good to go!
 
 For those planning to contribute to this project, you can run a dev version of the dashboard with the following commands:
 
-    $ mix deps.get
-    $ npm install --prefix assets
+    $ mix setup
     $ mix dev
 
 Alternatively, run `iex -S mix run dev.exs` if you also want a shell.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ For those planning to contribute to this project, you can run a dev version of t
 
     $ mix deps.get
     $ npm install --prefix assets
-    $ mix run --no-halt dev.exs
+    $ mix dev
 
 Alternatively, run `iex -S mix run dev.exs` if you also want a shell.
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule Phoenix.LiveDashboard.MixProject do
       name: "LiveDashboard",
       docs: docs(),
       homepage_url: "http://www.phoenixframework.org",
-      description: "Real-time performance dashboard for Phoenix"
+      description: "Real-time performance dashboard for Phoenix",
+      aliases: aliases()
     ]
   end
 
@@ -27,6 +28,12 @@ defmodule Phoenix.LiveDashboard.MixProject do
     [
       mod: {Phoenix.LiveDashboard.Application, []},
       extra_applications: [:logger]
+    ]
+  end
+
+  defp aliases do
+    [
+      dev: "run --no-halt dev.exs"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Phoenix.LiveDashboard.MixProject do
 
   defp aliases do
     [
+      setup: ["deps.get", "cmd npm install --prefix assets"],
       dev: "run --no-halt dev.exs"
     ]
   end


### PR DESCRIPTION
Getting started on making use of `:description` and whatnot in the dashboard, I noticed that it would be nice to have an alias for kicking off the development server.

```bash
# Before
$ mix run --no-halt dev.exs

# Now
$ mix dev
```