### PR TITLE
Display a hint for metric description

### DIFF
--- a/assets/css/app/components/_charts.scss
+++ b/assets/css/app/components/_charts.scss
@@ -5,6 +5,11 @@
   .card {
     padding: 0.5rem;
 
+    .hint {
+      position: absolute;
+      right: 14px;
+    }
+
     .uplot {
       font-family: 'LiveDashboardFont';
       max-width: 100%;

--- a/dev.exs
+++ b/dev.exs
@@ -35,6 +35,7 @@ defmodule DemoWeb.Telemetry do
     [
       # Phoenix Metrics
       last_value("phoenix.endpoint.stop.duration",
+        description: "Last value of phoenix.endpoint response time",
         unit: {:native, :millisecond}
       ),
       counter("phoenix.endpoint.stop.duration",

--- a/lib/phoenix/live_dashboard/live/chart_component.ex
+++ b/lib/phoenix/live_dashboard/live/chart_component.ex
@@ -14,6 +14,7 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
       if metric do
         assign(socket,
           title: chart_title(metric),
+          description: metric.description,
           kind: chart_kind(metric.__struct__),
           label: chart_label(metric),
           tags: Enum.join(metric.tags, "-"),
@@ -47,6 +48,11 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
               data-unit="<%= @unit %>">
           </div>
         </div>
+        <%= if @description do %>
+          <%= hint do %>
+            <%= @description %>
+          <% end %>
+        <% end %>
       </div>
     </div>
     """

--- a/test/phoenix/live_dashboard/live/chart_component_test.exs
+++ b/test/phoenix/live_dashboard/live/chart_component_test.exs
@@ -54,5 +54,20 @@ defmodule Phoenix.LiveDashboard.ChartComponentTest do
       result = render_chart(metric: last_value([:a, :b, :c, :count]), data: [{nil, "y", "z"}])
       assert result =~ ~s|<span data-x="Count" data-y="y" data-z="z">|
     end
+
+    test "renders a description hint when a description is provided" do
+      description = "test description"
+
+      result =
+        render_chart(
+          metric: last_value([:a, :b, :c, :count], description: description),
+          data: [{"x", "y", "z"}]
+        )
+
+      assert result =~ description
+
+      result = render_chart(metric: last_value([:a, :b, :c, :count]), data: [{"x", "y", "z"}])
+      refute result =~ description
+    end
   end
 end


### PR DESCRIPTION
As promised on [Twitter](https://twitter.com/mcrumm/status/1253776962893393920?s=20), this PR adds the ability to surface the `:description` of metrics.

<img width="1920" alt="Screen Shot 2020-04-26 at 8 15 46 AM" src="https://user-images.githubusercontent.com/1019721/80307521-96522a00-8797-11ea-9008-68b7de7fc088.png">

This was slightly more annoying than I thought it would be, as uPlot does not support anything other than title. I used the hint "component" and absolutely positioned it into the right corner. I am not a designer, so if there is a more aesthetic place to put this, I am happy to change it. It may be limited by having to work around uPlot.