### PR TITLE
Differentiate each metric by kind

### DIFF
--- a/lib/phoenix/live_dashboard/live/chart_component.ex
+++ b/lib/phoenix/live_dashboard/live/chart_component.ex
@@ -53,7 +53,13 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   end
 
   defp chart_title(metric) do
-    "#{Enum.join(metric.name, ".")}#{chart_tags(metric.tags)}"
+    "#{chart_type_name(metric)}(#{Enum.join(metric.name, ".")})#{chart_tags(metric.tags)}"
+  end
+
+  defp chart_type_name(%module{}) do
+    module
+    |> chart_kind()
+    |> to_string()
   end
 
   defp chart_tags([]), do: ""


### PR DESCRIPTION
On the metrics page, unless you look at the axis labels and units, it is not obvious what type of metric you're looking at. This manifests when looking at metrics for the same event. The same title will be duplicated each time without displaying the metric.

**This PR is mostly to get a conversation started.** I'm not sure of the best way to display this information. For now I displayed is as a function acting on the event.

Separately, it also may be nice to display the `event_name` rather than `name`, and highlight the measurement separately.

<img width="1806" alt="Screen Shot 2020-04-26 at 10 45 40 AM" src="https://user-images.githubusercontent.com/1019721/80311096-a6740480-87ab-11ea-9286-dab0026f53f0.png">
