### PR TITLE
home page refactor to reusable components

### DIFF
--- a/assets/css/app/_variables.scss
+++ b/assets/css/app/_variables.scss
@@ -100,6 +100,5 @@ $font-family-sans-serif: 'LiveDashboardFont', -apple-system, BlinkMacSystemFont,
 $badge-border-radius: 3px;
 $btn-border-radius: 3px;
 $primary: $color-dashboard;
-
 // Other
 $border-radius: 6px;

--- a/assets/css/app/components/_resource_usage.scss
+++ b/assets/css/app/components/_resource_usage.scss
@@ -28,12 +28,28 @@
     width: 16px;
   }
 
-  .resource-usage-legend-entries {
-    height: 100px;
+  .resource-usage-legend-entries-2 {
+    height: 64px;
   }
 
-  .resource-usage-legend-entry {
+  .resource-usage-legend-entries-3 {
+    height: 96px;
+  }
+
+  .resource-usage-legend-entries-4 {
+    height: 128px;
+  }
+
+  .resource-usage-legend-entry-2 {
+    flex-basis: 50%;
+  }
+
+  .resource-usage-legend-entry-3 {
     flex-basis: 33%;
+  }
+
+  .resource-usage-legend-entry-4 {
+    flex-basis: 25%;
   }
 
   .resource-usage-total {
@@ -48,11 +64,15 @@
 
 @media (max-width: map-get($grid-breakpoints, lg)) {
   .resource-usage {
-    .resource-usage-legend-entries {
+    .resource-usage-legend-entries-2,
+    .resource-usage-legend-entries-3,
+    .resource-usage-legend-entries-4 {
       height: auto;
     }
 
-    .resource-usage-legend-entry {
+    .resource-usage-legend-entry-2,
+    .resource-usage-legend-entry-3,
+    .resource-usage-legend-entry-4 {
       flex-basis: auto;
     }
   }

--- a/lib/phoenix/live_dashboard/helpers/view_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/view_helpers.ex
@@ -111,6 +111,19 @@ defmodule Phoenix.LiveDashboard.ViewHelpers do
   end
 
   @doc """
+  Formats percent.
+  """
+  def format_percent(percent) when is_integer(percent) do
+    "#{percent}%"
+  end
+
+  def format_percent(percent) when is_float(percent) do
+    "#{Float.floor(percent, 1)}%"
+  end
+
+  def format_percent(nil), do: "0%"
+
+  @doc """
   Formats words as bytes.
   """
   def format_words(words) when is_integer(words) do
@@ -137,10 +150,23 @@ defmodule Phoenix.LiveDashboard.ViewHelpers do
     "#{:erlang.float_to_binary(value, decimals: 1)} #{unit}"
   end
 
+  def format_k_bytes(kbytes) when is_integer(kbytes) do
+    format_bytes(kbytes * 1024)
+  end
+
   defp memory_unit(:TB), do: 1024 * 1024 * 1024 * 1024
   defp memory_unit(:GB), do: 1024 * 1024 * 1024
   defp memory_unit(:MB), do: 1024 * 1024
   defp memory_unit(:KB), do: 1024
+
+  def percentage(value, total, options \\ [])
+  def percentage(_value, 0, _options), do: 0
+
+  def percentage(value, total, options) do
+    percent = Float.round(value / total * 100, 2)
+
+    if options[:round], do: round(percent), else: percent
+  end
 
   @doc """
   Shows a hint.

--- a/lib/phoenix/live_dashboard/live/color_bar_component.ex
+++ b/lib/phoenix/live_dashboard/live/color_bar_component.ex
@@ -1,0 +1,24 @@
+defmodule Phoenix.LiveDashboard.ColorBarComponent do
+  use Phoenix.LiveDashboard.Web, :live_component
+
+  def render(assigns) do
+    ~L"""
+    <div class="progress flex-grow-1 mb-3">
+    <%= for {_ , name, value, color} <- @data do %>
+      <div
+      title="<%=name %> - <%= format_percent(value) %>"
+      class="progress-bar resource-usage-section-1 bg-gradient-<%= color %>"
+      role="progressbar"
+      aria-valuenow="<%= maybe_round(value) %>"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      style="width: <%= value %>%">
+      </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp maybe_round(num) when is_integer(num), do: num
+  defp maybe_round(num), do: Float.ceil(num, 1)
+end

--- a/lib/phoenix/live_dashboard/live/color_bar_legend_component.ex
+++ b/lib/phoenix/live_dashboard/live/color_bar_legend_component.ex
@@ -3,7 +3,7 @@ defmodule Phoenix.LiveDashboard.ColorBarLegendComponent do
 
   def render(assigns) do
     height = if assigns[:height], do: assigns[:height], else: 3
-    fn_format = if assigns[:fn_format], do: assigns[:fn_format], else: &format_percent(&1)
+    formatter = if assigns[:formatter], do: assigns[:formatter], else: &format_percent(&1)
 
     ~L"""
     <div class="resource-usage-legend">
@@ -13,7 +13,7 @@ defmodule Phoenix.LiveDashboard.ColorBarLegendComponent do
           <div class="resource-usage-legend-color bg-<%= color %> mr-2"></div>
           <span><%= name %></span>
           <span class="flex-grow-1 text-right text-muted">
-          <%= fn_format.(value) %>
+          <%= formatter.(value) %>
           </span>
         </div>
         <% end %>

--- a/lib/phoenix/live_dashboard/live/color_bar_legend_component.ex
+++ b/lib/phoenix/live_dashboard/live/color_bar_legend_component.ex
@@ -1,0 +1,24 @@
+defmodule Phoenix.LiveDashboard.ColorBarLegendComponent do
+  use Phoenix.LiveDashboard.Web, :live_component
+
+  def render(assigns) do
+    height = if assigns[:height], do: assigns[:height], else: 3
+    fn_format = if assigns[:fn_format], do: assigns[:fn_format], else: &format_percent(&1)
+
+    ~L"""
+    <div class="resource-usage-legend">
+      <div class="resource-usage-legend-entries-<%= height %> row flex-column flex-wrap">
+      <%= for {_ , name, value, color} <- @data do %>
+        <div class="col-lg-6 resource-usage-legend-entry-<%= height %> d-flex align-items-center py-1 flex-grow-0">
+          <div class="resource-usage-legend-color bg-<%= color %> mr-2"></div>
+          <span><%= name %></span>
+          <span class="flex-grow-1 text-right text-muted">
+          <%= fn_format.(value) %>
+          </span>
+        </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -179,7 +179,7 @@ defmodule Phoenix.LiveDashboard.HomeLive do
         <div class="card mb-4">
           <div class="card-body resource-usage">
             <%= live_component @socket, ColorBarComponent, id: :usage, data: memory_usage_sections_percent(@system_usage.memory, @system_usage.memory.total) %>
-            <%= live_component @socket, ColorBarLegendComponent, id: :usage_legend, data: memory_usage_sections(@system_usage.memory), fn_format: &format_bytes(&1) %>
+            <%= live_component @socket, ColorBarLegendComponent, data: memory_usage_sections(@system_usage.memory), formatter: &format_bytes(&1) %>
             <div class="row">
               <div class="col">
                 <div class="resource-usage-total text-center py-1 mt-3">

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -1,6 +1,12 @@
 defmodule Phoenix.LiveDashboard.HomeLive do
   use Phoenix.LiveDashboard.Web, :live_view
-  alias Phoenix.LiveDashboard.{SystemInfo, SystemLimitComponent}
+
+  alias Phoenix.LiveDashboard.{
+    SystemInfo,
+    ColorBarComponent,
+    ColorBarLegendComponent,
+    SystemLimitComponent
+  }
 
   @temporary_assigns [system_info: nil, system_usage: nil]
 
@@ -172,59 +178,29 @@ defmodule Phoenix.LiveDashboard.HomeLive do
 
         <div class="card mb-4">
           <div class="card-body resource-usage">
-
-            <div class="progress flex-grow-1 mb-3">
-              <%= for {_, section_name, section_value, color} <- memory_usage_sections(@system_usage.memory) do %>
-                <div
-                  title="<%=section_name %> - <%=percentage(section_value, @system_usage.memory.total, round: true) %>%"
-                  class="progress-bar bg-gradient-<%= color %>"
-                  role="progressbar"
-                  aria-valuenow="<%=section_value %>"
-                  aria-valuemin="0"
-                  aria-valuemax="<%=@system_usage.memory.total %>"
-                  style="width: <%=percentage(section_value, @system_usage.memory.total) %>%">
-                </div>
-              <% end %>
-            </div>
-
-            <div class="resource-usage-legend">
-
-              <div class="resource-usage-legend-entries row flex-column flex-wrap">
-                <%= for {_, section_name, section_value, color} <- memory_usage_sections(@system_usage.memory) do %>
-                  <div class="col-lg-6 resource-usage-legend-entry d-flex align-items-center py-1 flex-grow-0">
-                    <div class="resource-usage-legend-color bg-<%= color %> mr-2"></div>
-                    <span><%=section_name %></span>
-                    <span class="flex-grow-1 text-right text-muted">
-                      <%= format_bytes(section_value) %>
-                    </span>
-                  </div>
-                <% end %>
-              </div>
-
-              <div class="row">
-                <div class="col">
-                  <div class="resource-usage-total text-center py-1 mt-3">
-                    Total usage: <%= format_bytes(@system_usage.memory[:total]) %>
-                  </div>
+            <%= live_component @socket, ColorBarComponent, id: :usage, data: memory_usage_sections_percent(@system_usage.memory, @system_usage.memory.total) %>
+            <%= live_component @socket, ColorBarLegendComponent, id: :usage_legend, data: memory_usage_sections(@system_usage.memory), fn_format: &format_bytes(&1) %>
+            <div class="row">
+              <div class="col">
+                <div class="resource-usage-total text-center py-1 mt-3">
+                  Total usage: <%= format_bytes(@system_usage.memory[:total]) %>
                 </div>
               </div>
-
             </div>
           </div>
         </div>
+
       </div>
     </div>
     """
   end
 
-  defp percentage(value, total, options \\ [])
-
-  defp percentage(_value, 0, _options), do: 0
-
-  defp percentage(value, total, options) do
-    percent = Float.round(value / total * 100, 2)
-
-    if options[:round], do: round(percent), else: percent
+  defp memory_usage_sections_percent(memory_usage, total) do
+    memory_usage
+    |> memory_usage_sections()
+    |> Enum.map(fn {k, n, value, c} ->
+      {k, n, percentage(value, total), c}
+    end)
   end
 
   defp memory_usage_sections(memory_usage) do

--- a/test/phoenix/live_dashboard/live/color_bar_component_test.exs
+++ b/test/phoenix/live_dashboard/live/color_bar_component_test.exs
@@ -1,0 +1,26 @@
+defmodule Phoenix.LiveDashboard.ColorBarComponentTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Phoenix.LiveDashboard.ColorBarComponent
+  @endpoint Phoenix.LiveDashboardTest.Endpoint
+
+  @data [
+    {:in_use_memory, "In use", 4.0, "purple"}
+  ]
+
+  describe "rendering" do
+    test "color bar component" do
+      result = render_bar(@data)
+      assert result =~ "bg-gradient-purple"
+      assert result =~ "aria-valuenow=\"4.0\""
+      assert result =~ "style=\"width: 4.0%\""
+      assert result =~ "title=\"In use - 4.0%\""
+    end
+  end
+
+  defp render_bar(data) do
+    render_component(ColorBarComponent, id: :id, data: data)
+  end
+end

--- a/test/phoenix/live_dashboard/live/color_bar_legend_component_test.exs
+++ b/test/phoenix/live_dashboard/live/color_bar_legend_component_test.exs
@@ -1,0 +1,37 @@
+defmodule Phoenix.LiveDashboard.ColorBarLegendComponentTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.LiveDashboard.ColorBarLegendComponent
+  import Phoenix.LiveViewTest
+
+  @endpoint Phoenix.LiveDashboardTest.Endpoint
+
+  @data [
+    {:in_use_memory, "In use", 4.0, "purple"}
+  ]
+
+  describe "rendering" do
+    test "color bar component" do
+      result = render_component(ColorBarLegendComponent, id: :id, data: @data)
+      assert result =~ "bg-purple"
+      assert result =~ "4.0%"
+      assert result =~ "resource-usage-legend-entry-3"
+    end
+
+    test "color bar component override height" do
+      result = render_component(ColorBarLegendComponent, id: :id, data: @data, height: 2)
+      assert result =~ "resource-usage-legend-entry-2"
+      refute result =~ "resource-usage-legend-entry-3"
+    end
+
+    test "color bar component override formatter" do
+      result =
+        render_component(ColorBarLegendComponent, id: :id, data: @data, fn_format: &custom_f(&1))
+
+      refute result =~ "4.0%"
+      assert result =~ "400"
+    end
+  end
+
+  defp custom_f(val), do: val * 100
+end

--- a/test/phoenix/live_dashboard/live/color_bar_legend_component_test.exs
+++ b/test/phoenix/live_dashboard/live/color_bar_legend_component_test.exs
@@ -26,12 +26,12 @@ defmodule Phoenix.LiveDashboard.ColorBarLegendComponentTest do
 
     test "color bar component override formatter" do
       result =
-        render_component(ColorBarLegendComponent, id: :id, data: @data, fn_format: &custom_f(&1))
+        render_component(ColorBarLegendComponent, id: :id, data: @data, formatter: &formatter(&1))
 
       refute result =~ "4.0%"
       assert result =~ "400"
     end
   end
 
-  defp custom_f(val), do: val * 100
+  defp formatter(val), do: val * 100
 end


### PR DESCRIPTION
I created a separate bar and legend - this way I can use the bar separatly or render multiple bars on top of one legend