### PR TITLE
Fix 'no function clause matching in Float.ceil/2' os_mon error

### DIFF
--- a/lib/phoenix/live_dashboard/live/color_bar_component.ex
+++ b/lib/phoenix/live_dashboard/live/color_bar_component.ex
@@ -20,5 +20,6 @@ defmodule Phoenix.LiveDashboard.ColorBarComponent do
   end
 
   defp maybe_round(num) when is_integer(num), do: num
-  defp maybe_round(num), do: Float.ceil(num, 1)
+  defp maybe_round(num) when is_float(num), do: Float.ceil(num, 1)
+  defp maybe_round(_), do: 0
 end


### PR DESCRIPTION
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1810732/80606261-65425580-8a34-11ea-81c6-bbaa4d121000.png)|![image](https://user-images.githubusercontent.com/1810732/80606161-417f0f80-8a34-11ea-82d4-eff5134a6817.png)|

Visiting the os_mon when running the dashboard on my laptop causes an error - I assume that some values are not being reported and return `nil`. 
