### PR TITLE
Support for buffering recent historical data and streaming to metrics dashboards

### DIFF
--- a/lib/phoenix/live_dashboard/telemetry_listener.ex
+++ b/lib/phoenix/live_dashboard/telemetry_listener.ex
@@ -15,9 +15,18 @@ defmodule Phoenix.LiveDashboard.TelemetryListener do
     GenServer.start_link(__MODULE__, {parent, metrics})
   end
 
-  def handle_metrics(_event_name, measurements, metadata, {parent, metrics}) do
-    time = System.system_time(:second)
+  def handle_metrics(
+        _event_name,
+        measurements,
+        %{explicit_time: time} = metadata,
+        {parent, metrics}
+      ),
+      do: do_handle_metrics(time, measurements, metadata, {parent, metrics})
 
+  def handle_metrics(_event_name, measurements, metadata, {parent, metrics}),
+    do: do_handle_metrics(System.system_time(:second), measurements, metadata, {parent, metrics})
+
+  defp do_handle_metrics(time, measurements, metadata, {parent, metrics}) do
     entries =
       for {metric, index} <- metrics do
         if measurement = extract_measurement(metric, measurements) do


### PR DESCRIPTION
To be clear, this is less of a PR and more of an issue with partial proof-of-concept attached.

All this does is add optional handling for passing in explicit_time for buffered data, and is a possible first step towards allowing us to have a buffer of data we keep in the application so that when opening metrics, we have some number of cycles of previous metrics already available.

Locally in my phoenix app I've just tested this working with a genserver that's hit by telemetry_poller to emit data, and updated it to use a circular buffer to store the most recent n emissions, and rebroadcast the old ones with `explicit_time` metadata, and the charts are working correctly, at least on first render.  I think some further work/help is needed to make this play nicely or perhaps to broadcast consumption so that the buffer only re-emits the old timestamps once while live_dashboard is listening, or to move an optional buffer inside live dashboard somewhere so it can cleanly support each socket only reading history once.

I'd love to help make this happen for real, ideally as a configurable optional behavior built into live dashboard, or as an open source extension built on top of it if its not suited to be in the project directly for scope reasons, but I think something like these changes and/or perhaps some way to direct data only to new live dashboard connections/metrics pages when they first open.  Thanks so much for the awesome work from everyone though, I love having all of this power and data at my fingertips right in Phoenix! 
❤️ 💜 ❤️ 💙 ❤️ 