### PR TITLE
Adds option for showing environment variable on home page

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -103,7 +103,7 @@ defmodule DemoWeb.Router do
     get "/", DemoWeb.PageController, :index
     get "/hello", DemoWeb.PageController, :hello
     get "/hello/:name", DemoWeb.PageController, :hello
-    live_dashboard("/dashboard", metrics: DemoWeb.Telemetry, environment: ["USER", "ROOTDIR"])
+    live_dashboard("/dashboard", metrics: DemoWeb.Telemetry, env_keys: ["USER", "ROOTDIR"])
   end
 end
 

--- a/dev.exs
+++ b/dev.exs
@@ -103,7 +103,7 @@ defmodule DemoWeb.Router do
     get "/", DemoWeb.PageController, :index
     get "/hello", DemoWeb.PageController, :hello
     get "/hello/:name", DemoWeb.PageController, :hello
-    live_dashboard("/dashboard", metrics: DemoWeb.Telemetry)
+    live_dashboard("/dashboard", metrics: DemoWeb.Telemetry, environment: ["USER", "ROOTDIR"])
   end
 end
 

--- a/lib/phoenix/live_dashboard/environment.ex
+++ b/lib/phoenix/live_dashboard/environment.ex
@@ -1,0 +1,9 @@
+defmodule Phoenix.LiveDashboard.Environment do
+  # Helpers for fetching and formatting environment information.
+  @moduledoc false
+
+  def fetch_info(nil), do: nil
+  def fetch_info(keys) do
+    Enum.map(keys, fn key -> {key, System.get_env(key)} end)
+  end
+end

--- a/lib/phoenix/live_dashboard/environment.ex
+++ b/lib/phoenix/live_dashboard/environment.ex
@@ -1,9 +1,0 @@
-defmodule Phoenix.LiveDashboard.Environment do
-  # Helpers for fetching and formatting environment information.
-  @moduledoc false
-
-  def fetch_info(nil), do: nil
-  def fetch_info(keys) do
-    Enum.map(keys, fn key -> {key, System.get_env(key)} end)
-  end
-end

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -5,8 +5,7 @@ defmodule Phoenix.LiveDashboard.HomeLive do
     SystemInfo,
     ColorBarComponent,
     ColorBarLegendComponent,
-    SystemLimitComponent,
-    Environment
+    SystemLimitComponent
   }
 
   @temporary_assigns [system_info: nil, system_usage: nil]
@@ -39,7 +38,7 @@ defmodule Phoenix.LiveDashboard.HomeLive do
       system_usage: system_usage
     } = SystemInfo.fetch_system_info(socket.assigns.menu.node)
 
-    environment = Environment.fetch_info(session["environment"])
+    environment = fetch_environment_info(session["env_keys"])
 
     socket =
       assign(socket,
@@ -69,20 +68,6 @@ defmodule Phoenix.LiveDashboard.HomeLive do
             <%= @system_info.banner %> [<%= @system_info.system_architecture %>]
           </div>
         </div>
-
-        <%= if @environment do %>
-          <h5 class="card-title">Environment</h5>
-
-          <div class="card mb-4">
-            <div class="card-body rounded">
-              <dl>
-              <%= for {k, v} <- @environment do %>
-                <dt><%= k %><dd><%= v %></dd>
-              <% end %>
-              </dl>
-            </div>
-          </div>
-        <% end %>
 
         <!-- Row with colorful version banners -->
         <div class="row">
@@ -160,6 +145,20 @@ defmodule Phoenix.LiveDashboard.HomeLive do
             </div>
           </div>
         </div>
+
+        <%= if @environment do %>
+          <h5 class="card-title">Environment</h5>
+
+          <div class="card mb-4">
+            <div class="card-body rounded">
+              <dl>
+              <%= for {k, v} <- @environment do %>
+                <dt><%= k %></dt><dd><%= v %></dd>
+              <% end %>
+              </dl>
+            </div>
+          </div>
+        <% end %>
       </div>
 
       <!-- Right column containing system usage information -->
@@ -239,4 +238,9 @@ defmodule Phoenix.LiveDashboard.HomeLive do
   end
 
   defp versions_sections(), do: @versions_sections
+
+  defp fetch_environment_info(nil), do: nil
+  defp fetch_environment_info(keys) do
+    Enum.map(keys, fn key -> {key, System.get_env(key)} end)
+  end
 end

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -5,7 +5,8 @@ defmodule Phoenix.LiveDashboard.HomeLive do
     SystemInfo,
     ColorBarComponent,
     ColorBarLegendComponent,
-    SystemLimitComponent
+    SystemLimitComponent,
+    Environment
   }
 
   @temporary_assigns [system_info: nil, system_usage: nil]
@@ -38,11 +39,14 @@ defmodule Phoenix.LiveDashboard.HomeLive do
       system_usage: system_usage
     } = SystemInfo.fetch_system_info(socket.assigns.menu.node)
 
+    environment = Environment.fetch_info(session["environment"])
+
     socket =
       assign(socket,
         system_info: system_info,
         system_limits: system_limits,
-        system_usage: system_usage
+        system_usage: system_usage,
+        environment: environment
       )
 
     {:ok, socket, temporary_assigns: @temporary_assigns}
@@ -65,6 +69,20 @@ defmodule Phoenix.LiveDashboard.HomeLive do
             <%= @system_info.banner %> [<%= @system_info.system_architecture %>]
           </div>
         </div>
+
+        <%= if @environment do %>
+          <h5 class="card-title">Environment</h5>
+
+          <div class="card mb-4">
+            <div class="card-body rounded">
+              <dl>
+              <%= for {k, v} <- @environment do %>
+                <dt><%= k %><dd><%= v %></dd>
+              <% end %>
+              </dl>
+            </div>
+          </div>
+        <% end %>
 
         <!-- Row with colorful version banners -->
         <div class="row">

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -32,13 +32,12 @@ defmodule Phoenix.LiveDashboard.HomeLive do
     %{
       # Read once
       system_info: system_info,
+      environment: environment,
       # Kept forever
       system_limits: system_limits,
       # Updated periodically
       system_usage: system_usage
-    } = SystemInfo.fetch_system_info(socket.assigns.menu.node)
-
-    environment = SystemInfo.fetch_environment_info(socket.assigns.menu.node, session["env_keys"])
+    } = SystemInfo.fetch_system_info(socket.assigns.menu.node, session["env_keys"])
 
     socket =
       assign(socket,

--- a/lib/phoenix/live_dashboard/live/home_live.ex
+++ b/lib/phoenix/live_dashboard/live/home_live.ex
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveDashboard.HomeLive do
       system_usage: system_usage
     } = SystemInfo.fetch_system_info(socket.assigns.menu.node)
 
-    environment = fetch_environment_info(session["env_keys"])
+    environment = SystemInfo.fetch_environment_info(socket.assigns.menu.node, session["env_keys"])
 
     socket =
       assign(socket,
@@ -238,9 +238,4 @@ defmodule Phoenix.LiveDashboard.HomeLive do
   end
 
   defp versions_sections(), do: @versions_sections
-
-  defp fetch_environment_info(nil), do: nil
-  defp fetch_environment_info(keys) do
-    Enum.map(keys, fn key -> {key, System.get_env(key)} end)
-  end
 end

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -81,17 +81,25 @@ defmodule Phoenix.LiveDashboard.Router do
                   "such as {MyAppWeb.Telemetry, :metrics}, got: #{inspect(other)}"
       end
 
+    environment =
+      case options[:environment] do
+        nil -> nil
+        keys when is_list(keys) -> keys
+        other -> raise ArgumentError,
+              ":environment must be a list of strings, got: #{inspect(other)}"
+      end
     [
-      session: {__MODULE__, :__session__, [metrics]},
+      session: {__MODULE__, :__session__, [metrics, environment]},
       layout: {Phoenix.LiveDashboard.LayoutView, :dash},
       as: :live_dashboard
     ]
   end
 
   @doc false
-  def __session__(conn, metrics) do
+  def __session__(conn, metrics, environment) do
     %{
       "metrics" => metrics,
+      "environment" => environment,
       "request_logger" => Phoenix.LiveDashboard.RequestLogger.param_key(conn)
     }
   end

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -15,6 +15,10 @@ defmodule Phoenix.LiveDashboard.Router do
       It can be a `module` or a `{module, function}`. If nothing is
       given, the metrics functionality will be disabled.
 
+    * `:env_keys` - Configures environment variables to display.
+      It is defined as a list of string keys. If not set, the environment
+      information will not be displayed.
+
   ## Examples
 
       defmodule MyAppWeb.Router do
@@ -23,7 +27,9 @@ defmodule Phoenix.LiveDashboard.Router do
 
         scope "/", MyAppWeb do
           pipe_through [:browser]
-          live_dashboard "/dashboard", metrics: {MyAppWeb.Telemetry, :metrics}
+          live_dashboard "/dashboard",
+            metrics: {MyAppWeb.Telemetry, :metrics},
+            env_keys: ["APP_USER", "VERSION"]
         end
       end
 

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -81,25 +81,25 @@ defmodule Phoenix.LiveDashboard.Router do
                   "such as {MyAppWeb.Telemetry, :metrics}, got: #{inspect(other)}"
       end
 
-    environment =
-      case options[:environment] do
+    env_keys =
+      case options[:env_keys] do
         nil -> nil
         keys when is_list(keys) -> keys
         other -> raise ArgumentError,
-              ":environment must be a list of strings, got: #{inspect(other)}"
+              ":env_keys must be a list of strings, got: #{inspect(other)}"
       end
     [
-      session: {__MODULE__, :__session__, [metrics, environment]},
+      session: {__MODULE__, :__session__, [metrics, env_keys]},
       layout: {Phoenix.LiveDashboard.LayoutView, :dash},
       as: :live_dashboard
     ]
   end
 
   @doc false
-  def __session__(conn, metrics, environment) do
+  def __session__(conn, metrics, env_keys) do
     %{
       "metrics" => metrics,
-      "environment" => environment,
+      "env_keys" => env_keys,
       "request_logger" => Phoenix.LiveDashboard.RequestLogger.param_key(conn)
     }
   end

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -56,6 +56,10 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     :rpc.call(node, __MODULE__, :os_mon_callback, [])
   end
 
+  def fetch_environment_info(node, keys) do
+    :rpc.call(node, __MODULE__, :env_info_callback, [keys])
+  end
+
   ## System callbacks
 
   @doc false
@@ -363,6 +367,13 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     }
   end
 
+  ### Environment info callbacks
+
+  def env_info_callback(nil), do: nil
+
+  def env_info_callback(keys) do
+    Enum.map(keys, fn key -> {key, System.get_env(key)} end)
+  end
   ## Helpers
 
   defp format_call({m, f, a}), do: Exception.format_mfa(m, f, a)

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -44,8 +44,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     :rpc.call(node, __MODULE__, :ets_info_callback, [ref])
   end
 
-  def fetch_system_info(node) do
-    :rpc.call(node, __MODULE__, :info_callback, [])
+  def fetch_system_info(node, keys) do
+    :rpc.call(node, __MODULE__, :info_callback, [keys])
   end
 
   def fetch_system_usage(node) do
@@ -56,14 +56,10 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     :rpc.call(node, __MODULE__, :os_mon_callback, [])
   end
 
-  def fetch_environment_info(node, keys) do
-    :rpc.call(node, __MODULE__, :env_info_callback, [keys])
-  end
-
   ## System callbacks
 
   @doc false
-  def info_callback do
+  def info_callback(keys) do
     %{
       system_info: %{
         banner: :erlang.system_info(:system_version),
@@ -77,7 +73,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
         ports: :erlang.system_info(:port_limit),
         processes: :erlang.system_info(:process_limit)
       },
-      system_usage: usage_callback()
+      system_usage: usage_callback(),
+      environment: env_info_callback(keys)
     }
   end
 

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -23,12 +23,12 @@ defmodule Phoenix.LiveDashboard.RouterTest do
     end
   end
 
-  test "accepts environment option" do
-    assert Router.__options__(environment: ["USER", "ROOTDIR"])[:session] ==
+  test "accepts env_keys option" do
+    assert Router.__options__(env_keys: ["USER", "ROOTDIR"])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__, [nil, ["USER", "ROOTDIR"]]}
 
     assert_raise ArgumentError, fn ->
-      Router.__options__(environment: "FOO")
+      Router.__options__(env_keys: "FOO")
     end
   end
 end

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -5,7 +5,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
   test "sets options" do
     assert Router.__options__([]) == [
-             session: {Phoenix.LiveDashboard.Router, :__session__, [nil]},
+             session: {Phoenix.LiveDashboard.Router, :__session__, [nil, nil]},
              layout: {Phoenix.LiveDashboard.LayoutView, :dash},
              as: :live_dashboard
            ]
@@ -13,13 +13,22 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
   test "normalizes metrics option" do
     assert Router.__options__(metrics: Foo)[:session] ==
-             {Phoenix.LiveDashboard.Router, :__session__, [{Foo, :metrics}]}
+             {Phoenix.LiveDashboard.Router, :__session__, [{Foo, :metrics}, nil]}
 
     assert Router.__options__(metrics: {Foo, :bar})[:session] ==
-             {Phoenix.LiveDashboard.Router, :__session__, [{Foo, :bar}]}
+             {Phoenix.LiveDashboard.Router, :__session__, [{Foo, :bar}, nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(metrics: [])
+    end
+  end
+
+  test "accepts environment option" do
+    assert Router.__options__(environment: ["USER", "ROOTDIR"])[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__, [nil, ["USER", "ROOTDIR"]]}
+
+    assert_raise ArgumentError, fn ->
+      Router.__options__(environment: "FOO")
     end
   end
 end


### PR DESCRIPTION
This is my first PR into live_dashboard, so forgive me if there are things I missed. Hopefully, this can be merged with minimal changes :D

This PR solves: #106 

I went with a semantic display of the env vars keys and values as a definition list. Of course, I am not sure that it is styled in a preferred way.

![image](https://user-images.githubusercontent.com/773380/81113439-79c39980-8edd-11ea-87d3-b2809ae2f842.png)
