### PR TITLE
hidden nodes support

### DIFF
--- a/lib/phoenix/live_dashboard/helpers/live_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/live_helpers.ex
@@ -37,6 +37,8 @@ defmodule Phoenix.LiveDashboard.LiveHelpers do
     end
   end
 
-  def nodes(), do: [node()] ++ Node.list() ++ Node.list(:hidden)
-
+  @doc """
+  All connected nodes (including the current node).
+  """
+  def nodes(), do: [node()] ++ Node.list(:connected)
 end

--- a/lib/phoenix/live_dashboard/helpers/live_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/live_helpers.ex
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveDashboard.LiveHelpers do
   """
   def assign_defaults(socket, params, session, refresher? \\ false) do
     param_node = Map.fetch!(params, "node")
-    found_node = Enum.find([node() | Node.list()], &(Atom.to_string(&1) == param_node))
+    found_node = Enum.find(nodes(), &(Atom.to_string(&1) == param_node))
 
     socket =
       Phoenix.LiveView.assign(socket, :menu, %{
@@ -36,4 +36,7 @@ defmodule Phoenix.LiveDashboard.LiveHelpers do
       Phoenix.LiveView.push_redirect(socket, to: live_dashboard_path(socket, :home, node()))
     end
   end
+
+  def nodes(), do: [node()] ++ Node.list() ++ Node.list(:hidden)
+
 end

--- a/lib/phoenix/live_dashboard/live/menu_live.ex
+++ b/lib/phoenix/live_dashboard/live/menu_live.ex
@@ -141,8 +141,6 @@ defmodule Phoenix.LiveDashboard.MenuLive do
 
   ## Node helpers
 
-  defp nodes(), do: [node() | Node.list()]
-
   defp validate_nodes_or_redirect(socket) do
     if socket.assigns.node not in nodes() do
       socket


### PR DESCRIPTION
This prevents clusters leaking.
Say we have a dashboard attached for each cluster and don't want the clusters to share their nodes.
All dashboards are in the dashboard menu.
