### PR TITLE
Allow skipping assets optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ For those planning to contribute to this project, you can run a dev version of t
 
 Alternatively, run `iex -S mix dev` if you also want a shell.
 
+Assets are minimized by default. If you'd like to skip assets optimization and run webpack in development mode you can do it using the `NODE_ENV` enviroment variable:
+
+    $ NODE_ENV=development mix dev
+
+or
+
+    $ NODE_ENV=development iex -S mix dev
+
 ## License
 
 MIT License. Copyright (c) 2019 Michael Crumm, Chris McCord, José Valim.

--- a/dev.exs
+++ b/dev.exs
@@ -14,7 +14,7 @@ Application.put_env(:phoenix_live_dashboard, DemoWeb.Endpoint,
     node: [
       "node_modules/webpack/bin/webpack.js",
       "--mode",
-      "production",
+      System.get_env("NODE_ENV") || "production",
       "--watch-stdin",
       cd: "assets"
     ]


### PR DESCRIPTION
## Added changes

Based on our discussion in https://github.com/phoenixframework/phoenix_live_dashboard/pull/154 I propose using `NODE_ENV` to skip assets minification when necessary.

`NODE_ENV=development mix dev` will run webpack in development mode - in this mode minification steps are ignored.

This allows us to easily debug JS code.

|Default|NODE_ENV=development|
|--|--|
|![image](https://user-images.githubusercontent.com/1810732/84602712-a332f600-ae89-11ea-88ec-80ef140f38d8.png)|![image](https://user-images.githubusercontent.com/1810732/84602744-dbd2cf80-ae89-11ea-8729-bf204be9aa75.png)|

## Comment/Question

Typically we would expect webpack to run in `development` mode by default and switch to `production` when necessary (ie. during deployment).

I just didn't want to mess with our current workflow - if I changed the default to `development` we would have to remember to always build assets in production mode before submitting them. 

Or maybe it's not a big deal and I should just use `development` as the default env?

Resolves #150 