### PR TITLE
Remove compiler warning on Elixir master

### DIFF
--- a/lib/phoenix/live_dashboard/helpers/live_helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers/live_helpers.ex
@@ -20,16 +20,16 @@ defmodule Phoenix.LiveDashboard.LiveHelpers do
   Encodes Sockets for URLs.
   """
   def encode_socket(ref) do
-    [_hash, _P, _o, _r, _t | port] = :erlang.port_to_list(ref)
-    "Socket#{port}"
+    '#Port' ++ rest = :erlang.port_to_list(ref)
+    "Socket#{rest}"
   end
 
   @doc """
   Encodes ETSs for URLs.
   """
   def encode_ets(ref) do
-    [_hash, _R, _e, _f | ref] = :erlang.ref_to_list(ref)
-    "ETS#{ref}"
+    '#Ref' ++ rest = :erlang.ref_to_list(ref)
+    "ETS#{rest}"
   end
 
   @doc """


### PR DESCRIPTION
Before this patch, we were triggering:

    warning: unknown compiler variable "_P" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)
      lib/phoenix/live_dashboard/helpers/live_helpers.ex:23: Phoenix.LiveDashboard.LiveHelpers.encode_socket/1

    warning: unknown compiler variable "_R" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)
      lib/phoenix/live_dashboard/helpers/live_helpers.ex:31: Phoenix.LiveDashboard.LiveHelpers.encode_ets/1

I'd consider this occurence as a bit of a false positive (per
https://github.com/elixir-lang/elixir/pull/10198#issuecomment-658953515),
but I think the patch is an improvement regardless if I may say so
myself. :-)