### PR TITLE
add recommended Elixir and Erlang/OTP combinations to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,30 @@ name: CI
 on:
   pull_request:
   push:
-      branches:
+    branches:
       - master
 
 jobs:
   mix_test:
-    name: mix test (OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}})
-    strategy:
-      matrix:
-        otp: [21.x, 22.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x]
+    name: mix test (Elixir ${{matrix.elixir}} | OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: [21.3.8.17, 22.3.4.5]
+        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4]
+        include:
+          - elixir: 1.9.4
+            otp: 21.3.8.17
+            warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
+          - elixir: 1.10.4
+            otp: 23.0.3
+            check_formatted: true
+    env:
+      MIX_ENV: test
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/checkout@v2
+    - uses: actions/setup-elixir@v1
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
@@ -25,6 +35,10 @@ jobs:
         mix local.rebar --force
         mix local.hex --force
         mix deps.get
+    - run: mix format --check-formatted
+      if: matrix.check_formatted
+    - run: mix compile --warnings-as-errors
+      if: matrix.warnings_as_errors
     - name: Run Tests
       run: mix test
 
@@ -32,8 +46,8 @@ jobs:
     name: npm test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-elixir@v1.2.0
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
         with:
           otp-version: 22.x
           elixir-version: 1.9.x

--- a/lib/phoenix/live_dashboard.ex
+++ b/lib/phoenix/live_dashboard.ex
@@ -16,7 +16,8 @@ defmodule Phoenix.LiveDashboard do
   Note that it is expected that the event name was already validated as
   part of the metric.
   """
-  @spec extract_datapoint_for_metric(Telemetry.Metric.t, map(), map(), pos_integer | nil) ::
-    %{label: binary(), measurement: number, time: pos_integer} | nil
-  defdelegate extract_datapoint_for_metric(metric, measurements, metadata, time \\ nil), to: Phoenix.LiveDashboard.TelemetryListener
+  @spec extract_datapoint_for_metric(Telemetry.Metric.t(), map(), map(), pos_integer | nil) ::
+          %{label: binary(), measurement: number, time: pos_integer} | nil
+  defdelegate extract_datapoint_for_metric(metric, measurements, metadata, time \\ nil),
+    to: Phoenix.LiveDashboard.TelemetryListener
 end


### PR DESCRIPTION
This pull request makes sure all recommended Elixir and Erlang/OTP combinations are run on CI.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

Additional functionality: make sure there are no compilation warnings and checks formatting.