### PR TITLE
PageBuilder capabilities

### DIFF
--- a/lib/phoenix/live_dashboard/components/menu_component.ex
+++ b/lib/phoenix/live_dashboard/components/menu_component.ex
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveDashboard.MenuComponent do
   use Phoenix.LiveDashboard.Web, :live_component
 
   @derive {Inspect, only: []}
-  defstruct pages: %{},
+  defstruct links: [],
             nodes: [],
             refresher?: true,
             refresh: 5,
@@ -14,8 +14,8 @@ defmodule Phoenix.LiveDashboard.MenuComponent do
     ~L"""
     <div id="menu">
       <nav id="menu-bar">
-        <%= for {route, result} <- @menu.pages do %>
-          <%= maybe_link(@socket, @page, route, result) %>
+        <%= for link <- @menu.links do %>
+          <%= maybe_link(@socket, @page, link) %>
         <% end %>
       </nav>
 
@@ -52,38 +52,34 @@ defmodule Phoenix.LiveDashboard.MenuComponent do
     """
   end
 
-  defp maybe_link(socket, page, route, result) do
-    case result do
-      {:ok, text} ->
-        if Atom.to_string(page.route) == route do
-          content_tag(:div, text, class: "menu-item active")
-        else
-          live_redirect(text,
-            to: live_dashboard_path(socket, route, page.node, []),
-            class: "menu-item"
-          )
-        end
+  defp maybe_link(_socket, _page, {:current, text}) do
+    content_tag(:div, text, class: "menu-item active")
+  end
 
-      {:disabled, text} ->
-        assigns = %{text: text}
+  defp maybe_link(socket, page, {:enabled, text, route}) do
+    live_redirect(text,
+      to: live_dashboard_path(socket, route, page.node, []),
+      class: "menu-item"
+    )
+  end
 
-        ~L"""
-        <div class="menu-item menu-item-disabled">
-          <%= @text %>
-        </div>
-        """
+  defp maybe_link(_socket, _page, {:disabled, text}) do
+    assigns = %{text: text}
 
-      {:disabled, text, more_info_url} ->
-        assigns = %{more_info_url: more_info_url, text: text}
+    ~L"""
+    <div class="menu-item menu-item-disabled">
+      <%= @text %>
+    </div>
+    """
+  end
 
-        ~L"""
-        <div class="menu-item menu-item-disabled">
-          <%= @text %> <%= link "Enable", to: @more_info_url, class: "menu-item-enable-button" %>
-        </div>
-        """
+  defp maybe_link(_socket, _page, {:disabled, text, more_info_url}) do
+    assigns = %{more_info_url: more_info_url, text: text}
 
-      :skip ->
-        []
-    end
+    ~L"""
+    <div class="menu-item menu-item-disabled">
+      <%= @text %> <%= link "Enable", to: @more_info_url, class: "menu-item-enable-button" %>
+    </div>
+    """
   end
 end

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -30,9 +30,9 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   argument in the `c:menu_link/2` callback.
   The possible values are:
 
-  * `:app` to detect if the app is running or not.
-  * `:module` to detect if the module is loaded or not.
-  * `:pid` to detect if the pid exists or not.
+  * `:applications` list of applications that are running or not.
+  * `:modules` list of modules that are loaded or not.
+  * `:pids` list of processes that alive or not.
   """
   @callback init(term()) :: {:ok, session} | {:ok, session, requirements}
 

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     * `:pids` list of processes that alive or not.
 
   """
-  @callback init(term()) :: {:ok, session} | {:ok, session, requirements}
+  @callback init(term()) :: {:ok, session()} | {:ok, session(), requirements()}
 
   @doc """
   Callback invoked when a page is declared in the router.
@@ -48,19 +48,22 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   The possible return values are:
 
-  * `{:ok, text}` when the link should be enable and text to be shown.
-  * `{:disabled, text}` when the link should be disable and text to be shown.
-  * `{:disabled, text, more_info_url}` similar to the previous one but
-  it also includes a link to provide more information to the user.
-  * `:skip` when the link should not be shown at all.
+    * `{:ok, text}` when the link should be enable and text to be shown.
+
+    * `{:disabled, text}` when the link should be disable and text to be shown.
+
+    * `{:disabled, text, more_info_url}` similar to the previous one but
+      it also includes a link to provide more information to the user.
+
+    * `:skip` when the link should not be shown at all.
   """
-  @callback menu_link(session, capabilities()) ::
+  @callback menu_link(session(), capabilities()) ::
               {:ok, String.t()}
               | {:disabled, String.t()}
               | {:disabled, String.t(), String.t()}
               | :skip
 
-  @callback mount(unsigned_params(), session, socket :: Socket.t()) ::
+  @callback mount(unsigned_params(), session(), socket :: Socket.t()) ::
               {:ok, Socket.t()} | {:ok, Socket.t(), keyword()}
 
   @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -22,17 +22,21 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   It receives the router options and it must return the
   tuple `{:ok, session, requirements}`.
+
   The page session will be serialized to the client and
   received on `mount`.
+
   The requirements is an optional keyword to detect the
   state of the node.
+
   The result of this detection will be passed as second
   argument in the `c:menu_link/2` callback.
   The possible values are:
 
-  * `:applications` list of applications that are running or not.
-  * `:modules` list of modules that are loaded or not.
-  * `:pids` list of processes that alive or not.
+    * `:applications` list of applications that are running or not.
+    * `:modules` list of modules that are loaded or not.
+    * `:pids` list of processes that alive or not.
+
   """
   @callback init(term()) :: {:ok, session} | {:ok, session, requirements}
 

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -35,6 +35,11 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   @menu_text "OS Data"
 
   @impl true
+  def init(opts) do
+    {:ok, opts, application: :os_mon}
+  end
+
+  @impl true
   def mount(_params, _session, socket) do
     socket = assign_os_mon(socket)
     {:ok, socket, temporary_assigns: @temporary_assigns}
@@ -95,12 +100,12 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   end
 
   @impl true
-  def menu_link(_, %{os_mon: enabled?}) do
-    if enabled? do
-      {:ok, @menu_text}
-    else
-      {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/os_mon.html"}
-    end
+  def menu_link(_, %{applications: %{os_mon: true}}) do
+    {:ok, @menu_text}
+  end
+
+  def menu_link(_, %{applications: %{os_mon: false}}) do
+    {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/os_mon.html"}
   end
 
   @impl true

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -36,7 +36,7 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
 
   @impl true
   def init(opts) do
-    {:ok, opts, application: :os_mon}
+    {:ok, opts, applications: :os_mon}
   end
 
   @impl true

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -184,9 +184,9 @@ defmodule Phoenix.LiveDashboard.Router do
 
   defp normalize_requirements(requirements) do
     %{
-      applications: normalize_requirement(requirements, :application),
-      modules: normalize_requirement(requirements, :module),
-      pids: normalize_requirement(requirements, :pid)
+      applications: normalize_requirement(requirements, :applications),
+      modules: normalize_requirement(requirements, :modules),
+      pids: normalize_requirement(requirements, :pids)
     }
   end
 

--- a/test/phoenix/live_dashboard/components/menu_component_test.exs
+++ b/test/phoenix/live_dashboard/components/menu_component_test.exs
@@ -19,11 +19,11 @@ defmodule Phoenix.LiveDashboard.MenuComponentTest do
       struct(
         %MenuComponent{
           nodes: [node()],
-          pages: [
-            {"link", {:ok, "Link"}},
-            {"disabled", {:disabled, "Disabled"}},
-            {"disabled_link", {:disabled, "DisabledLink", "https://example.com"}},
-            {"skip", :skip}
+          links: [
+            {:current, "Current"},
+            {:enabled, "Link", "link"},
+            {:disabled, "Disabled"},
+            {:disabled, "DisabledLink", "https://example.com"}
           ],
           refresh: 5,
           refresh_options: [{"1s", 1}, {"2s", 2}, {"5s", 5}],
@@ -59,8 +59,8 @@ defmodule Phoenix.LiveDashboard.MenuComponentTest do
     end
 
     test "when a link is active" do
-      render = render_menu([], route: :link)
-      assert render =~ ~s|<div class="menu-item active">Link</div>|
+      render = render_menu()
+      assert render =~ ~s|<div class="menu-item active">Current</div>|
     end
 
     test "disables elements with enable link" do

--- a/test/phoenix/live_dashboard/pages/os_mon_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/os_mon_page_test.exs
@@ -8,10 +8,13 @@ defmodule Phoenix.LiveDashboard.OSMonPageTest do
   test "menu_link/2" do
     link = "https://hexdocs.pm/phoenix_live_dashboard/os_mon.html"
 
-    assert {:disabled, "OS Data", ^link} =
-             Phoenix.LiveDashboard.OSMonPage.menu_link(%{}, %{os_mon: false})
+    capabilities = %{applications: %{os_mon: false}}
 
-    assert {:ok, "OS Data"} = Phoenix.LiveDashboard.OSMonPage.menu_link(%{}, %{os_mon: true})
+    assert {:disabled, "OS Data", ^link} =
+             Phoenix.LiveDashboard.OSMonPage.menu_link(%{}, capabilities)
+
+    capabilities = %{applications: %{os_mon: true}}
+    assert {:ok, "OS Data"} = Phoenix.LiveDashboard.OSMonPage.menu_link(%{}, capabilities)
   end
 
   describe "OS mon page" do


### PR DESCRIPTION
I added a data API to allow the custom pages to ask for requirements in the current node. Currently, it allows asking for running applications, loaded modules, and living processes. It makes a single request to the node with the aggregated information of all pages, but then only passes the required information to each page.

I also had to modify the MenuComponent a little and now it receives "links". I can change it again to "pages" if you don't like it--for me "page" means a PageBuilder.