### PR TITLE
Replace PageBuilder.render by PageBuilder.render_page that only works with components

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -1,50 +1,5 @@
 defmodule Phoenix.LiveDashboard.TableComponent do
   @moduledoc false
-
-  # `Phoenix.LiveComponent` to render a simple table.
-
-  # This component is used in different pages like applications or sockets.
-  # It can be used in a `Phoenix.LiveView` in the `render/1` function:
-
-  # ```
-  # def render(assigns) do
-  #   ~L\"""
-  #     <%= live_component(assigns.socket, Phoenix.LiveDashboard.TableComponent, options) %>
-  #   \"""
-  # end
-  # ```
-
-  # # Options
-
-  # These are the options supported by the component:
-
-  # * `:id` - Required. Because is a stateful `Phoenix.LiveComponent` an unique id is needed.
-  # * `:columns` - Required. A `Keyword` list with the following keys:
-  #   * `:field` - Required. An identifier for the column.
-  #   * `:header` - Label to show in the current column. Default value is calculated from `:field`.
-  #   * `:header_attrs` - A list with HTML attributes for the column header.
-  #     More info: `Phoenix.HTML.Tag.tag/1`. Default `[]`.
-  #   * `:format` - Function which receives the row data and returns the cell information.
-  #     Default is calculated from `:field`: `row[:field]`.
-  #   * `:cell_attrs` - A list with HTML attributes for the table cell.
-  #     It also can be a function which receives the row data and returns an attribute list.
-  #     More info: `Phoenix.HTML.Tag.tag/1`. Default: `[]`.
-  #   * `:sortable` - A boolean. When it is true the column header is clickable
-  #     and it fetches again rows with the new order.  At least one column should be sortable.
-  #     Default: `false`
-  # * `:limit_options` - A list of integers to limit the number of rows to show.
-  #   Default: `[50, 100, 500, 1000, 5000]`
-  # * `:page_name` - Required. The name of current `Phoenix.LiveView`.
-  # * `:params` - Required. All the params received by the parent `Phoenix.LiveView`,
-  #   so the table can handle its own parameters.
-  # * `:row_fetcher` - Required. A function which receives the params and the node and
-  #   returns a tuple with the rows and the total number:
-  #   `(params(), node()) -> {list(), integer() | binary()}`
-  # * `:rows_name` - A string to name the representation of the rows.
-  #   Default is calculated with the given `:page_name`.
-  # * `:title` - The title of the table.
-  #   Default is calculated with the given `:page_name`.
-
   use Phoenix.LiveDashboard.Web, :live_component
 
   @sort_dir ~w(desc asc)

--- a/lib/phoenix/live_dashboard/helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers.ex
@@ -2,15 +2,7 @@ defmodule Phoenix.LiveDashboard.Helpers do
   @moduledoc false
 
   import Phoenix.LiveView.Helpers
-
   @format_limit 100
-
-  @doc """
-  Renders a `Phoenix.LiveDashboard.TableComponent` component
-  """
-  def table(%Phoenix.LiveView.Socket{} = socket, table_assigns) do
-    live_component(socket, Phoenix.LiveDashboard.TableComponent, table_assigns)
-  end
 
   @doc """
   Computes a route path to the live dashboard.

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -151,9 +151,25 @@ defmodule Phoenix.LiveDashboard.PageLive do
     </header>
     <%= live_info(@socket, @page) %>
     <section id="main" role="main" class="container">
-      <%= @page.module.render(assigns) %>
+      <%= render_page(@socket, @page.module, assigns) %>
     </section>
     """
+  end
+
+  # Those pages are handled especially outside of the component tree.
+  defp render_page(_socket, module, assigns)
+       when module in [
+              Phoenix.LiveDashboard.HomePage,
+              Phoenix.LiveDashboard.MetricsPage,
+              Phoenix.LiveDashboard.OSMonPage,
+              Phoenix.LiveDashboard.RequestLoggerPage
+            ] do
+    module.render(assigns)
+  end
+
+  defp render_page(socket, module, assigns) do
+    {component, component_assigns} = module.render_page(assigns)
+    live_component(socket, component, [page: assigns.page] ++ component_assigns)
   end
 
   defp live_info(_socket, %{info: nil}), do: nil

--- a/lib/phoenix/live_dashboard/pages/applications_page.ex
+++ b/lib/phoenix/live_dashboard/pages/applications_page.ex
@@ -8,21 +8,14 @@ defmodule Phoenix.LiveDashboard.ApplicationsPage do
   @menu_text "Applications"
 
   @impl true
-  def render(assigns) do
-    ~L"""
-      <%= table(@socket, table_assigns(@page)) %>
-    """
-  end
-
-  defp table_assigns(page) do
-    %{
+  def render_page(_assigns) do
+    table(
       columns: columns(),
       id: @table_id,
-      page: page,
       row_attrs: &row_attrs/1,
       row_fetcher: &fetch_applications/2,
       title: "Applications"
-    }
+    )
   end
 
   defp fetch_applications(params, node) do

--- a/lib/phoenix/live_dashboard/pages/ets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ets_page.ex
@@ -7,22 +7,15 @@ defmodule Phoenix.LiveDashboard.EtsPage do
   @menu_text "ETS"
 
   @impl true
-  def render(assigns) do
-    ~L"""
-      <%= table(@socket, table_assigns(@page)) %>
-    """
-  end
-
-  defp table_assigns(page) do
-    %{
+  def render_page(_assigns) do
+    table(
       columns: columns(),
       id: @table_id,
-      page: page,
       row_attrs: &row_attrs/1,
       row_fetcher: &fetch_ets/2,
       rows_name: "tables",
       title: "ETS"
-    }
+    )
   end
 
   defp fetch_ets(params, node) do

--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
   end
 
   @impl true
-  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+  def render_page(_assigns), do: raise("this page is special cased to use render/2 instead")
 
   def render(assigns) do
     ~L"""

--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -56,6 +56,8 @@ defmodule Phoenix.LiveDashboard.HomePage do
   end
 
   @impl true
+  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+
   def render(assigns) do
     ~L"""
     <div class="row">

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -55,7 +55,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
   end
 
   @impl true
-  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+  def render_page(_assigns), do: raise("this page is special cased to use render/2 instead")
 
   def render(assigns) do
     ~L"""

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -55,6 +55,8 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
   end
 
   @impl true
+  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+
   def render(assigns) do
     ~L"""
     <div class="row">

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -109,6 +109,8 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   end
 
   @impl true
+  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+
   def render(assigns) do
     ~L"""
     <div class="row">

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -109,7 +109,7 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   end
 
   @impl true
-  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+  def render_page(_assigns), do: raise("this page is special cased to use render/2 instead")
 
   def render(assigns) do
     ~L"""

--- a/lib/phoenix/live_dashboard/pages/ports_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ports_page.ex
@@ -7,21 +7,14 @@ defmodule Phoenix.LiveDashboard.PortsPage do
   @menu_text "Ports"
 
   @impl true
-  def render(assigns) do
-    ~L"""
-      <%= table(@socket, table_assigns(@page)) %>
-    """
-  end
-
-  defp table_assigns(page) do
-    %{
+  def render_page(_assigns) do
+    table(
       columns: columns(),
       id: @table_id,
-      page: page,
       row_attrs: &row_attrs/1,
       row_fetcher: &fetch_ports/2,
       title: "Ports"
-    }
+    )
   end
 
   defp fetch_ports(params, node) do

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -7,21 +7,14 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
   @menu_text "Processes"
 
   @impl true
-  def render(assigns) do
-    ~L"""
-    <%= table(@socket, table_assigns(@page)) %>
-    """
-  end
-
-  defp table_assigns(page) do
-    %{
+  def render_page(_assigns) do
+    table(
       columns: columns(),
       id: @table_id,
-      page: page,
       row_attrs: &row_attrs/1,
       row_fetcher: &fetch_processes/2,
       title: "Processes"
-    }
+    )
   end
 
   defp fetch_processes(params, node) do

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -66,6 +66,8 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
   end
 
   @impl true
+  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+
   def render(assigns) do
     ~L"""
     <!-- Card containing log messages -->

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -66,7 +66,7 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
   end
 
   @impl true
-  def render_page(_assigns), do: raise "this page is special cased to use render/2 instead"
+  def render_page(_assigns), do: raise("this page is special cased to use render/2 instead")
 
   def render(assigns) do
     ~L"""

--- a/lib/phoenix/live_dashboard/pages/sockets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/sockets_page.ex
@@ -7,21 +7,14 @@ defmodule Phoenix.LiveDashboard.SocketsPage do
   @menu_text "Sockets"
 
   @impl true
-  def render(assigns) do
-    ~L"""
-      <%= table(@socket, table_assigns(@page)) %>
-    """
-  end
-
-  defp table_assigns(page) do
-    %{
+  def render_page(_assigns) do
+    table(
       columns: columns(),
       id: @table_id,
-      page: page,
       row_attrs: &row_attrs/1,
       row_fetcher: &fetch_sockets/2,
       title: "Sockets"
-    }
+    )
   end
 
   defp fetch_sockets(params, node) do


### PR DESCRIPTION
@alexcastano this is in my opinion the last step: we are restricting page builders to only have components. What do you think about this approach?

If you think this is good, then the only missing parts are:

1. docs
2. add a tab component so we can use for the psql-info thing

Thoughts?