### PR TITLE
Fix current page in menu component

### DIFF
--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -93,7 +93,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   defp assign_menu_links(socket, pages, requirements) do
     node = socket.assigns.page.node
     capabilities = Phoenix.LiveDashboard.SystemInfo.node_capabilities(node, requirements)
-    current_route = socket.assigns.page.route
+    current_route = socket.assigns.page.route |> Atom.to_string()
 
     {links, socket} =
       Enum.map_reduce(pages, socket, fn {route, {module, session}}, socket ->

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -173,14 +173,18 @@ defmodule Phoenix.LiveDashboard.Router do
 
     %{
       "pages" => pages,
-      "requirements" => Enum.uniq(requirements)
+      "requirements" => requirements |> Enum.concat() |> Enum.uniq()
     }
   end
 
   defp initialize_page(module, opts) do
     case module.init(opts) do
-      {:ok, session} -> {session, []}
-      {:ok, session, requirements} -> {session, validate_requirements(module, requirements)}
+      {:ok, session} ->
+        {session, []}
+
+      {:ok, session, requirements} ->
+        validate_requirements(module, requirements)
+        {session, requirements}
     end
   end
 

--- a/test/phoenix/live_dashboard/pages/home_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/home_page_test.exs
@@ -42,7 +42,7 @@ defmodule Phoenix.LiveDashboard.HomePageTest do
   end
 
   test "is the current page in menu component" do
-    {:ok, live, rendered} = live(build_conn(), "/dashboard/nonode@nohost/home")
+    {:ok, _live, rendered} = live(build_conn(), "/dashboard/nonode@nohost/home")
     assert rendered =~ ~s|<div class="menu-item active">Home</div>|
   end
 end

--- a/test/phoenix/live_dashboard/pages/home_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/home_page_test.exs
@@ -42,8 +42,7 @@ defmodule Phoenix.LiveDashboard.HomePageTest do
   end
 
   test "is the current page in menu component" do
-    {:ok, live, _} = live(build_conn(), "/dashboard/nonode@nohost/home")
-    rendered = render(live)
+    {:ok, live, rendered} = live(build_conn(), "/dashboard/nonode@nohost/home")
     assert rendered =~ ~s|<div class="menu-item active">Home</div>|
   end
 end

--- a/test/phoenix/live_dashboard/pages/home_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/home_page_test.exs
@@ -40,4 +40,10 @@ defmodule Phoenix.LiveDashboard.HomePageTest do
     assert rendered =~ ~r|<span>Other </span>|
     assert rendered =~ ~r|Total usage: \d+.\d+|
   end
+
+  test "is the current page in menu component" do
+    {:ok, live, _} = live(build_conn(), "/dashboard/nonode@nohost/home")
+    rendered = render(live)
+    assert rendered =~ ~s|<div class="menu-item active">Home</div>|
+  end
 end

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -2,6 +2,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   use ExUnit.Case, async: true
 
   alias Phoenix.LiveDashboard.Router
+  import Phoenix.ConnTest
 
   test "default options" do
     assert Router.__options__([]) == [
@@ -72,6 +73,27 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
     assert_raise ArgumentError, fn ->
       Router.__options__(additional_pages: CustomPage)
+    end
+  end
+
+  describe "__session__/5" do
+    test "generates pages & requirements" do
+      assert %{
+               "pages" => [
+                 {"home", {Phoenix.LiveDashboard.HomePage, %{"env_keys" => []}}},
+                 {"os_mon", {Phoenix.LiveDashboard.OSMonPage, %{}}},
+                 {"metrics",
+                  {Phoenix.LiveDashboard.MetricsPage, %{"metrics" => [], "metrics_history" => []}}},
+                 {"request_logger",
+                  {Phoenix.LiveDashboard.RequestLoggerPage, %{"request_logger" => nil}}},
+                 {"applications", {Phoenix.LiveDashboard.ApplicationsPage, %{}}},
+                 {"processes", {Phoenix.LiveDashboard.ProcessesPage, %{}}},
+                 {"ports", {Phoenix.LiveDashboard.PortsPage, %{}}},
+                 {"sockets", {Phoenix.LiveDashboard.SocketsPage, %{}}},
+                 {"ets", {Phoenix.LiveDashboard.EtsPage, %{}}}
+               ],
+               "requirements" => [{:application, :os_mon}]
+             } = Phoenix.LiveDashboard.Router.__session__(build_conn(), [], [], [], [])
     end
   end
 end


### PR DESCRIPTION
The current page was being rendered as a enabled link instead of a the current page.
It also fixes a problem when calculating the page requirements.