### PR TITLE
Simplify normalize_params/1 functions

### DIFF
--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -144,24 +144,22 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   """
   @spec table(keyword()) :: component()
   def table(assigns) do
-    assigns = Map.new(assigns)
+    assigns =
+      assigns
+      |> Map.new()
+      |> TableComponent.normalize_params()
 
-    with {:ok, assigns} <- TableComponent.normalize_params(assigns) do
-      {TableComponent, assigns}
-    else
-      {:error, msg} -> raise ArgumentError, msg
-    end
+    {TableComponent, assigns}
   end
 
   @spec tab_bar(keyword()) :: component()
   def tab_bar(assigns) do
-    assigns = Map.new(assigns)
+    assigns =
+      assigns
+      |> Map.new()
+      |> TabBarComponent.normalize_params()
 
-    with {:ok, assigns} <- TabBarComponent.normalize_params(assigns) do
-      {TabBarComponent, assigns}
-    else
-      {:error, msg} -> raise ArgumentError, msg
-    end
+    {TabBarComponent, assigns}
   end
 
   defmacro __using__(opts) do

--- a/test/phoenix/live_dashboard/components/tab_bar_component_test.exs
+++ b/test/phoenix/live_dashboard/components/tab_bar_component_test.exs
@@ -69,48 +69,58 @@ defmodule Phoenix.LiveDashboard.Components.TabBarComponentTest do
     test "validates :tabs" do
       page = %Phoenix.LiveDashboard.PageBuilder{}
 
-      assert {:error, msg} = TabBarComponent.normalize_params(%{page: page})
-      assert msg == "expected :tabs parameter to be received"
+      assert_raise ArgumentError, "expected :tabs parameter to be received", fn ->
+        TabBarComponent.normalize_params(%{page: page})
+      end
 
-      assert {:error, msg} = TabBarComponent.normalize_params(%{page: page, tabs: :invalid})
-      assert msg == "expected :tabs parameter to be a list, received: :invalid"
+      msg = "expected :tabs parameter to be a list, received: :invalid"
 
-      assert {:error, msg} = TabBarComponent.normalize_params(%{page: page, tabs: [:invalid]})
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{page: page, tabs: :invalid})
+      end
 
-      assert msg ==
-               "expected :tabs to be [{atom(), [name: string(), render: component()], received: :invalid"
+      msg =
+        "expected :tabs to be [{atom(), [name: string(), render: component()], received: :invalid"
 
-      assert {:error, msg} = TabBarComponent.normalize_params(%{page: page, tabs: [id: []]})
-      assert msg == "expected :render parameter to be received in tab: []"
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{page: page, tabs: [:invalid]})
+      end
 
-      assert {:error, msg} =
-               TabBarComponent.normalize_params(%{
-                 page: page,
-                 tabs: [id: [render: :invalid]]
-               })
+      msg = "expected :render parameter to be received in tab: []"
 
-      assert msg ==
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{page: page, tabs: [id: []]})
+      end
+
+      assert msg =
                "expected :render parameter in tab to be a component, received: [render: :invalid]"
 
-      assert {:error, msg} =
-               TabBarComponent.normalize_params(%{
-                 page: page,
-                 tabs: [id: [render: {Component, [:args]}]]
-               })
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{
+          page: page,
+          tabs: [id: [render: :invalid]]
+        })
+      end
 
-      assert msg ==
-               "expected :name parameter to be received in tab: [render: {Component, [:args]}]"
+      msg = "expected :name parameter to be received in tab: [render: {Component, [:args]}]"
 
-      assert {:error, msg} =
-               TabBarComponent.normalize_params(%{
-                 page: page,
-                 tabs: [id: [name: "name", render: {Component, [:args]}, method: :invalid]]
-               })
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{
+          page: page,
+          tabs: [id: [render: {Component, [:args]}]]
+        })
+      end
 
-      assert msg ==
-               "expected :method parameter in tab to be :patch or :redirect, received: :invalid"
+      msg = "expected :method parameter in tab to be :patch or :redirect, received: :invalid"
 
-      assert {:ok, %{tabs: [id: tab]}} =
+      assert_raise ArgumentError, msg, fn ->
+        TabBarComponent.normalize_params(%{
+          page: page,
+          tabs: [id: [name: "name", render: {Component, [:args]}, method: :invalid]]
+        })
+      end
+
+      assert %{tabs: [id: tab]} =
                TabBarComponent.normalize_params(%{
                  page: page,
                  tabs: [id: [name: "name", render: {Component, [:args]}]]
@@ -120,7 +130,7 @@ defmodule Phoenix.LiveDashboard.Components.TabBarComponentTest do
       assert tab[:render] == {Component, [:args]}
       assert tab[:method] == :patch
 
-      assert {:ok, %{tabs: [id: tab]}} =
+      assert %{tabs: [id: tab]} =
                TabBarComponent.normalize_params(%{
                  page: page,
                  tabs: [id: [name: "name", method: :redirect, render: fn -> nil end]]


### PR DESCRIPTION
Raise when an error is detected instead of returning an {:error, msg}.