### PR TITLE
Scope component params

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -2,7 +2,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
   @moduledoc false
   use Phoenix.LiveDashboard.Web, :live_component
 
-  @sort_dir ~w(desc asc)
+  @sort_dir ~w(asc desc)
   @limit [50, 100, 500, 1000, 5000]
 
   @type params() :: %{
@@ -26,6 +26,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
     |> Map.put_new_lazy(:rows_name, fn ->
       Phoenix.Naming.humanize(params.title) |> String.downcase()
     end)
+    |> Map.put_new_lazy(:param_key, fn -> to_string(params.id) end)
   end
 
   defp validate_required(params, list) do
@@ -88,19 +89,22 @@ defmodule Phoenix.LiveDashboard.TableComponent do
   defp normalize_table_params(assigns) do
     %{
       columns: columns,
-      page: %{params: all_params},
+      page: page,
       limit_options: limit_options
     } = assigns
 
+    params = component_params(page)
+
     sortable_columns = sortable_columns(columns)
-    sort_by = all_params |> get_in_or_first("sort_by", sortable_columns) |> String.to_atom()
-    sort_dir = all_params |> get_in_or_first("sort_dir", @sort_dir) |> String.to_atom()
+    sort_by = params |> get_in_or_first("sort_by", sortable_columns) |> String.to_atom()
+    sort_dir = params |> get_in_or_first("sort_dir", @sort_dir) |> String.to_atom()
     limit_options = Enum.map(limit_options, &to_string/1)
-    limit = all_params |> get_in_or_first("limit", limit_options) |> String.to_integer()
-    search = all_params["search"]
+    limit = params |> get_in_or_first("limit", limit_options) |> String.to_integer()
+    search = params["search"]
     search = if search == "", do: nil, else: search
 
     table_params = %{sort_by: sort_by, sort_dir: sort_dir, limit: limit, search: search}
+
     Map.put(assigns, :table_params, table_params)
   end
 

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
             module: nil,
             node: nil,
             params: nil,
+            params_keys: [],
             route: nil,
             tick: 0
 

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -169,8 +169,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
 
   defp render_page(socket, module, assigns) do
     {component, component_assigns} = module.render_page(assigns)
-    component_assigns = Map.put(component_assigns, :page, assigns.page)
-    live_component(socket, component, component_assigns)
+    render_page_component(socket, assigns.page, component, component_assigns)
   end
 
   defp live_info(_socket, %{info: nil}), do: nil
@@ -245,7 +244,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   end
 
   def handle_event("show_info", %{"info" => info}, socket) do
-    to = live_dashboard_path(socket, socket.assigns.page, info: info)
+    to = show_info_path(socket, socket.assigns.page, info)
     {:noreply, push_patch(socket, to: to)}
   end
 

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -11,7 +11,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
     all_metrics = apply(mod, fun, [])
     metrics_per_tab = Enum.group_by(all_metrics, &tab_name/1)
 
-    tab = params["tab"]
+    tab = params["tabs"]["current"]
     metrics = metrics_per_tab[tab]
     {first_tab, _} = Enum.at(metrics_per_tab, 0, {nil, nil})
 
@@ -27,7 +27,8 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
         {:ok, assign(socket, metrics: Enum.with_index(metrics))}
 
       first_tab && is_nil(tab) ->
-        to = live_dashboard_path(socket, :metrics, socket.assigns.page.node, tab: first_tab)
+        url_params = [tabs: [current: first_tab]]
+        to = live_dashboard_path(socket, :metrics, socket.assigns.page.node, url_params)
         {:ok, push_redirect(socket, to: to)}
 
       true ->


### PR DESCRIPTION
A proof of concept to avoid too many params in the URL when there are many components on the same page.

We keep the hierarchy of the components in a new field: `%PageBuilder{params_keys: [child, parent]}` to remove the other when they aren't needed anymore.

I added a couple of helpers to make the params easier to use from the components. I put all of them in `Helpers` but maybe we want to move to a better place.

I think this approach may work as far as we keep the hierarchy to a single child---which is currently our case.

In the case we want to have more than a single child for the same parent, we will have problems with siblings and "uncles & cousins":

```
root
- a
  - a.1
  - a.2
- b
  - b.1
  - b.2
```  

If we update `b.2` params, we will keep `root`, `b` and `b.2` params, but we will remove `a`, `a.1`, `a.2` and `b.1`. A possible solution to this problem would be "hierarching" the params too, but maybe it isn't still necessary.

@josevalim I'd love your thoughts when you can because I'm not sure if you imagine the solution with something like this :D 