### PR TITLE
Use $initial_call from dictionary when available

### DIFF
--- a/lib/phoenix/live_dashboard/info/process_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/process_info_component.ex
@@ -7,6 +7,7 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
     :registered_name,
     :current_function,
     :initial_call,
+    :dictionary,
     :status,
     :message_queue_len,
     :links,
@@ -34,7 +35,7 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
           <tbody>
             <tr><td class="border-top-0">Registered name</td><td class="border-top-0"><pre><%= @registered_name %></pre></td></tr>
             <tr><td>Current function</td><td><pre><%= @current_function %></pre></td></tr>
-            <tr><td>Initial call</td><td><pre><%= @initial_call %></pre></td></tr>
+            <tr><td>Initial call</td><td><pre><%= @dictionary || @initial_call %></pre></td></tr>
             <tr><td>Status</td><td><pre><%= @status %></pre></td></tr>
             <tr><td>Message queue length</td><td><pre><%= @message_queue_len %></pre></td></tr>
             <tr><td>Links</td><td><pre><%= @links %></pre></td></tr>
@@ -87,6 +88,13 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
   defp format_info(key, val, live_dashboard_path)
        when key in [:links, :monitors, :monitored_by],
        do: format_value(val, live_dashboard_path)
+
+  defp format_info(:dictionary, dictionary, _) when is_list(dictionary) do
+    case Keyword.get(dictionary, :"$initial_call") do
+      nil -> nil
+      initial_call -> format_call(initial_call)
+    end
+  end
 
   defp format_info(:current_function, :undefined, _), do: "undefined"
   defp format_info(:current_function, val, _), do: format_call(val)

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -181,6 +181,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
   @process_info [
     :registered_name,
     :initial_call,
+    :dictionary,
     :memory,
     :reductions,
     :message_queue_len,
@@ -204,7 +205,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   defp process_info(pid) do
     if info = Process.info(pid, @process_info) do
-      [{:registered_name, name}, {:initial_call, initial_call} | rest] = info
+      [{:registered_name, name}, {:initial_call, initial_call}, {:dictionary, dictionary} | rest] = info
+      initial_call = Keyword.get(dictionary, :"$initial_call", initial_call)
       name_or_initial_call = if is_atom(name), do: inspect(name), else: format_call(initial_call)
       [pid: pid, name_or_initial_call: name_or_initial_call] ++ rest
     end

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -205,8 +205,9 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   defp process_info(pid) do
     if info = Process.info(pid, @process_info) do
-      [{:registered_name, name}, {:initial_call, initial_call}, {:dictionary, dictionary} | rest] = info
-      initial_call = Keyword.get(dictionary, :"$initial_call", initial_call)
+      [{:registered_name, name}, {:initial_call, initial_call}, {:dictionary, dict} | rest] = info
+
+      initial_call = Keyword.get(dict, :"$initial_call", initial_call)
       name_or_initial_call = if is_atom(name), do: inspect(name), else: format_call(initial_call)
       [pid: pid, name_or_initial_call: name_or_initial_call] ++ rest
     end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     end
 
     test "all with search" do
-      {pids, _count} = SystemInfo.fetch_processes(node(), "user", :memory, :asc, 100)
+      {pids, _count} = SystemInfo.fetch_processes(node(), ":user", :memory, :asc, 100)
       assert [[pid, name | _]] = pids
       assert pid == {:pid, Process.whereis(:user)}
       assert name == {:name_or_initial_call, ":user"}


### PR DESCRIPTION
I updated the `inital_call` field to use the `$initial_call` from the process dictionary over the processes `initial_call`.
The call in the dictionary looks more meaningful than the one of the process (which is often just `:proc_lib.init_p/5`).

With this change the dashboard would for example show `Plug.Cowboy.Drainer.init/1` instead of `:proc_lib.init_p/5` as `name_or_initial_call`.