### PR TITLE
Use relative path for link to metrics history page

### DIFF
--- a/guides/metrics.md
+++ b/guides/metrics.md
@@ -153,4 +153,4 @@ The following reporter options are available to the dashboard:
 
 ### Metrics history
 
-[Metrics history can also be enabled via a custom configuration](/metrics_history.html).
+[Metrics history can also be enabled via a custom configuration](metrics_history.html).


### PR DESCRIPTION
Avoids a broken link when published to Hexdocs (https://hexdocs.pm/phoenix_live_dashboard/metrics.html)