### PR TITLE
Fix documentation about metric nav group

### DIFF
--- a/guides/metrics.md
+++ b/guides/metrics.md
@@ -145,7 +145,7 @@ Reporter options can be given to each metric as an option. For example:
 
 The following reporter options are available to the dashboard:
 
-  * `:group` - configures the group the metric belongs to. By default the group is the first part of the name. For example, `counter("my_app.counter")` defaults to group "my_app"
+  * `:nav` - configures the group the metric belongs to. By default the group is the first part of the name. For example, `counter("my_app.counter")` defaults to group "my_app"
 
   * `:prune_threshold` - the maximum number of data
     points. When the threshold is reached, the chart data will


### PR DESCRIPTION
In the past, the name of the reporter option was `:group` but it changed to `:tab` in #182 and then to `:nav` in commit 53950c55a0db08cc2232787253c7daa4970f40c3.

I'm just updating the name of the option, but I'm not changing the description. Maybe we should change that too.