### PR TITLE
Skip Distribution Charts

### DIFF
--- a/lib/phoenix/live_dashboard/components/card_usage_component.ex
+++ b/lib/phoenix/live_dashboard/components/card_usage_component.ex
@@ -6,7 +6,10 @@ defmodule Phoenix.LiveDashboard.CardUsageComponent do
     <div class="card progress-section mb-4">
       <%= live_component @socket, Phoenix.LiveDashboard.TitleBarComponent, class: "card-body", percent: percentage(@usage, @limit) do %>
         <div>
-          <%= @inner_content.([]) %>
+          <%= case assigns do
+            %{inner_block: _inner_block} -> render_block @inner_block, []
+            %{inner_content: _inner_content} -> @inner_content.([])
+          end %>
         </div>
         <div>
           <small class="text-muted pr-2">

--- a/lib/phoenix/live_dashboard/components/chart_component.ex
+++ b/lib/phoenix/live_dashboard/components/chart_component.ex
@@ -1,6 +1,8 @@
 defmodule Phoenix.LiveDashboard.ChartComponent do
   use Phoenix.LiveDashboard.Web, :live_component
 
+  require Logger
+
   @default_prune_threshold 1_000
 
   @impl true
@@ -31,6 +33,10 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   end
 
   @impl true
+  def render(%{kind: :unsupported} = assigns) do
+    ~L""
+  end
+
   def render(assigns) do
     ~L"""
     <div class="col-xl-6 col-xxl-4 col-xxxl-3 charts-col">
@@ -74,8 +80,10 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   defp chart_kind(Telemetry.Metrics.Sum), do: :sum
   defp chart_kind(Telemetry.Metrics.Summary), do: :summary
 
-  defp chart_kind(Telemetry.Metrics.Distribution),
-    do: raise(ArgumentError, "LiveDashboard does not yet support distribution metrics")
+  defp chart_kind(Telemetry.Metrics.Distribution) do
+    Logger.warn("LiveDashboard does not yet support distribution metrics")
+    :unsupported
+  end
 
   defp chart_label(%{} = metric) do
     metric.name

--- a/lib/phoenix/live_dashboard/components/title_bar_component.ex
+++ b/lib/phoenix/live_dashboard/components/title_bar_component.ex
@@ -10,7 +10,10 @@ defmodule Phoenix.LiveDashboard.TitleBarComponent do
     <div class="<%= @class %>">
       <section>
         <div class="d-flex justify-content-between">
-          <%= @inner_content.([]) %>
+          <%= case assigns do
+            %{inner_block: _inner_block} -> render_block @inner_block, []
+            %{inner_content: _inner_content} -> @inner_content.([])
+          end %>
         </div>
         <div class="progress flex-grow-1 mt-2">
           <div


### PR DESCRIPTION
Until #7 is done, I'd like to skip distribution charts.

(I have one Telemetry Supervisor that is shared for the dashboard and a prometheus exporter. While prometheus does not support `summary`, the dashboard does not support `distribution`. This change allows me to use the same supervisor for both.)