### PR TITLE
Un-swap table sort icons

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -264,7 +264,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
     {:safe,
      """
      <div class="dash-table-icon">
-       <span class="icon-sort icon-asc"></span>
+       <span class="icon-sort icon-desc"></span>
      </div>
      """}
   end
@@ -273,7 +273,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
     {:safe,
      """
      <div class="dash-table-icon">
-       <span class="icon-sort icon-desc"></span>
+       <span class="icon-sort icon-asc"></span>
      </div>
      """}
   end


### PR DESCRIPTION
I happened to notice that the sort icons seemed backwards. It seems to me that the width of the triangle should match the "size" of the data, such that the point of the triangle should line up with the smallest data element, and the base of the triangle should line up with the biggest data element. If we call one triangle a cone and the other a pyramid, then the icon for cone-shaped data is the pyramid and vice-versa.

Pictures are probably a more useful description:
Before (sort by input desc): 
![sort by input desc, triangle pointing up](https://user-images.githubusercontent.com/29588/101660184-e0310d00-3a14-11eb-9954-54439eb926b0.png)
Before (sort by input asc):
![sort by input asc, triangle pointing down](https://user-images.githubusercontent.com/29588/101660289-0060cc00-3a15-11eb-8c9e-ecabfc662940.png)

After (sort by input desc):
![sort by input asc, triangle pointing down](https://user-images.githubusercontent.com/29588/101660386-1e2e3100-3a15-11eb-8515-7748297e17f3.png)
After (sort by input asc):
![sort by input asc, triangle pointing up](https://user-images.githubusercontent.com/29588/101660455-31d99780-3a15-11eb-83b1-541a3878f37c.png)
