### PR TITLE
Fix error message in router.ex when "path" of additional page is no atom

### DIFF
--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -204,8 +204,8 @@ defmodule Phoenix.LiveDashboard.Router do
       other ->
         msg =
           "invalid value in :additional_pages, " <>
-            "must be a tuple {path, {module, args}}, where path is a binary and " <>
-            "the module implements Phoenix.LiveDashboard.PageBuilder, got: "
+            "must be a tuple {path, {module, args}} or {path, module}, where path " <>
+            "is an atom and the module implements Phoenix.LiveDashboard.PageBuilder, got: "
 
         raise ArgumentError, msg <> inspect(other)
     end)


### PR DESCRIPTION
When an additional page is specified in the `router.ex`, but the `path` is no atom, then we should specify that only atoms are allow as `path` in the error message. Right now, it says that only `binaries` are allowed.