### PR TITLE
Guard against nil measurements when extracting datapoints

### DIFF
--- a/lib/phoenix/live_dashboard/telemetry_listener.ex
+++ b/lib/phoenix/live_dashboard/telemetry_listener.ex
@@ -29,11 +29,16 @@ defmodule Phoenix.LiveDashboard.TelemetryListener do
   end
 
   def extract_datapoint_for_metric(metric, measurements, metadata, time \\ nil) do
-    if keep?(metric, metadata) do
-      time = time || System.system_time(:microsecond)
-      measurement = extract_measurement(metric, measurements, metadata)
+    with {:keep?, true} <- {:keep?, keep?(metric, metadata)},
+         time = time || System.system_time(:microsecond),
+         {:measurement, measurement}
+         when measurement != nil <-
+           {:measurement, extract_measurement(metric, measurements, metadata)} do
       label = tags_to_label(metric, metadata)
       %{label: label, measurement: measurement, time: time}
+    else
+      {:keep?, false} -> nil
+      {:measurement, nil} -> nil
     end
   end
 

--- a/test/phoenix/live_dashboard/telemetry_listener_test.exs
+++ b/test/phoenix/live_dashboard/telemetry_listener_test.exs
@@ -72,4 +72,12 @@ defmodule Phoenix.LiveDashboard.TelemetryListenerTest do
     ref = Process.monitor(pid)
     assert_receive {:DOWN, ^ref, _, _, _}
   end
+
+  test "datapoint extraction returns nil when measurement not matched" do
+    metric = counter("a.b.c")
+    assert nil == TelemetryListener.extract_datapoint_for_metric(metric, %{d: 10}, %{})
+
+    assert %{measurement: 10} =
+             TelemetryListener.extract_datapoint_for_metric(metric, %{c: 10}, %{})
+  end
 end


### PR DESCRIPTION
I was following [the Configuring metrics history guide](https://hexdocs.pm/phoenix_live_dashboard/metrics_history.html) on adding historical metrics to the live dashboard but noticed that some times I would be getting `nil` measurements back.

The handler for each metric is attached based on `metric.event_name`, not `metric.name`. So for metrics like `counter("a.b.c")` and `counter("a.b.d")` the event_name for both is `[:a, :b]` which means that the same callback will be triggered. When doing `:telemetry.execute([:a, :b], %{e: 1}, %{})` the handler is thus executed but the datapoint returned from `Phoenix.LiveDashboard.extract_datapoint_for_metric/3` would contain `%{measurement: nil}` because it does not match the registered metrics' measurements

I also had trouble guarding against that because dialyzer would complain. When running against the following snippet
```elixir
case Phoenix.LiveDashboard.extract_datapoint_for_metric(metric, data, metadata) do
  %{measurement: nil} -> :ok
  datapoint -> GenServer.cast(server, {:telemetry_metric, datapoint, metric})
end
```

it would fail with the following warning

```elixir
The pattern can never match the type.

Pattern:
%{:measurement => nil}

Type:
nil | %{:label => binary(), :measurement => number(), :time => pos_integer()}

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```

Anyway, let me know if it makes sense to merge or if you need me to make any changes