### PR TITLE
add distribution chart to dashboard

### DIFF
--- a/assets/js/metrics_live/charts/distribution.js
+++ b/assets/js/metrics_live/charts/distribution.js
@@ -1,0 +1,203 @@
+import uPlot from 'uplot'
+import calculateStatistics from './distribution/statistics'
+import boxplot from './distribution/box_plot'
+import {
+  LineColor
+} from '../color_wheel'
+
+class Distribution {
+  constructor(options, chartEl) {
+    let config = this.constructor.getConfig(options)
+    this.chart = new uPlot(config, initialData(options), chartEl)
+    this.pruneThreshold = options.pruneThreshold || 1000;
+    this.options = options
+    this.datasets = {};
+  }
+
+  handleMeasurements(measurements) {
+    measurements.forEach(measurement => {
+      addMeasurement(this.datasets, measurement);
+    })
+    maybePruneDirtyDatasets(this.datasets, this.pruneThreshold);
+    maybeRecalculateStatistics(this.datasets);
+    let plotData = asPlotData(this.datasets);
+    this.chart.setData(plotData);
+  }
+
+  static getConfig(options) {
+
+    return {
+      class: options.kind,
+      title: options.title,
+      width: options.width,
+      height: options.height,
+      plugins: boxplot.plugins(boxPlotOptions()),
+      axes: [{
+        show: options.tagged,
+        rotate: 90,
+        space: 10,
+        size: 150,
+        grid: {
+          show: false
+        },
+        values: (_, vals) => vals
+      }, ],
+      scales: {
+        x: {
+          distr: 2,
+          time: false,
+        }
+      },
+      // the series labels correspond to box lines drawn in the boxPlot plugin
+      // which expects data to be at predetermined positions
+      // (ie median at index=1, q1 at index = 2 etc.)
+      series: [{
+          label: options.tags,
+          value: (_, val) => val,
+        },
+        {
+          label: "median",
+          value: seriesValueDisplay(options)
+        },
+        {
+          label: "q1",
+          value: seriesValueDisplay(options)
+        },
+        {
+          label: "q3",
+          value: seriesValueDisplay(options)
+        },
+        {
+          label: "min",
+          value: seriesValueDisplay(options)
+        },
+        {
+          label: "max",
+          value: seriesValueDisplay(options)
+        },
+      ],
+    }
+  }
+}
+
+function initialData() {
+  // [x-labels, medians, q1s, q3s, mins, maxs]
+  return [
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ]
+}
+
+function seriesValueDisplay(options) {
+  return (_, val) => {
+    if (options.unit) {
+      return `${val} ${options.unit}`
+    }
+    return val
+  }
+}
+
+function boxPlotOptions() {
+  let colors = {
+    box: LineColor.at(0),
+    col: LineColor.at(6),
+    legend: LineColor.at(4)
+  }
+
+  return {
+    columnHighlightPlugin: {
+      style: {
+        backgroundColor: colors.col.fill
+      }
+    },
+    legendAsTooltipPlugin: {
+      style: {
+        backgroundColor: colors.legend.overlay
+      }
+    },
+    boxesPlugin: {
+      bodyWidthFactor: 0.7,
+      style: {
+        outlineColor: colors.box.stroke,
+        fillColor: colors.box.fill
+      }
+    }
+  }
+}
+
+function addMeasurement(datasets, measurement) {
+  const {
+    x: tag,
+    y: value
+  } = measurement;
+  let dataset = datasets[tag] || {
+    values: [],
+    dirty: true
+  }
+  dataset.values.push(value);
+  dataset.dirty = true;
+
+  datasets[tag] = dataset;
+  return datasets;
+}
+
+function maybePruneDirtyDatasets(datasets, pruneThreshold) {
+  Object.keys(datasets)
+    .forEach(tag => {
+      let dataset = datasets[tag];
+      let size = dataset.values.length
+      if (size > pruneThreshold) {
+        dataset.values = dataset.values.slice(size / 2)
+      }
+    });
+}
+
+function maybeRecalculateStatistics(datasets) {
+  Object.keys(datasets)
+    .forEach(tag => {
+      let dataset = datasets[tag];
+      // a dataset can be dirty either because 
+      // new values were added and/or old values were pruned
+      if (dataset.dirty) {
+        dataset.stats = calculateStatistics(dataset.values);
+        dataset.dirty = false;
+      }
+    });
+}
+
+function asPlotData(datasets) {
+  return Object.keys(datasets)
+    // sort by alphabetical order of tags
+    .sort((tag1, tag2) => {
+      return tag1.localeCompare(tag2)
+    })
+    .reduce((plotData, tag) => {
+      let dataset = datasets[tag];
+
+      const {
+        median,
+        q1,
+        q3,
+        min,
+        max
+      } = dataset.stats;
+
+      // make sure the order is the same as the series labels
+      let values = [tag, fixVal(median), fixVal(q1), fixVal(q3), fixVal(min), fixVal(max)]
+      for (let i = 0; i < values.length; i++) {
+        plotData[i].push(values[i]);
+      }
+
+      return plotData;
+    }, initialData())
+}
+
+function fixVal(val) {
+  return val && !isNaN(val) ? val.toFixed(2) : 0;
+}
+
+export default Distribution

--- a/assets/js/metrics_live/charts/distribution/box_plot.js
+++ b/assets/js/metrics_live/charts/distribution/box_plot.js
@@ -1,0 +1,297 @@
+import uPlot from 'uplot'
+
+// column-highlights the hovered x index
+function columnHighlightPlugin({
+  className,
+  style = {
+    backgroundColor: "rgba(51,204,255,0.3)"
+  }
+} = {}) {
+  let underEl, overEl, highlightEl, currIdx;
+
+  function init(u) {
+    underEl = u.root.querySelector(".u-under");
+    underEl.style.overflow = "visible";
+    overEl = u.root.querySelector(".u-over");
+
+    highlightEl = document.createElement("div");
+
+    className && highlightEl.classList.add(className);
+
+    uPlot.assign(highlightEl.style, {
+      pointerEvents: "none",
+      display: "none",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      height: "100%",
+      overflow: true,
+      ...style
+    });
+
+    underEl.appendChild(highlightEl);
+
+    // show/hide highlight on enter/exit
+    overEl.addEventListener("mouseenter", () => {
+      highlightEl.style.display = null;
+    });
+    overEl.addEventListener("mouseleave", () => {
+      highlightEl.style.display = "none";
+    });
+  }
+
+  function update(u) {
+    if (currIdx !== u.cursor.idx) {
+      currIdx = u.cursor.idx;
+
+      const dx = u.scales.x.max - u.scales.x.min;
+      let width, left;
+      if (dx > 0) {
+        width = (u.bbox.width / dx) / devicePixelRatio;
+        left = u.valToPos(currIdx, "x") - width / 2;
+      } else {
+        // just one tag visible
+        width = u.bbox.width / devicePixelRatio;
+        left = 0;
+      }
+
+      highlightEl.style.transform = "translateX(" + Math.round(left) + "px)";
+      highlightEl.style.width = Math.round(width) + "px";
+    }
+  }
+
+  return {
+    opts: (u, opts) => {
+      uPlot.assign(opts, {
+        cursor: {
+          x: false,
+          y: false,
+        }
+      });
+    },
+    hooks: {
+      init: init,
+      setCursor: update,
+    }
+  };
+}
+
+// converts the legend into a simple tooltip
+function legendAsTooltipPlugin({
+  className,
+  style = {
+    backgroundColor: "rgba(255, 249, 196, 0.92)",
+    color: "black"
+  }
+} = {}) {
+  let legendEl;
+
+  function init(u, opts) {
+    legendEl = u.root.querySelector(".u-legend");
+
+    legendEl.classList.remove("u-inline");
+    className && legendEl.classList.add(className);
+
+    uPlot.assign(legendEl.style, {
+      textAlign: "left",
+      pointerEvents: "none",
+      display: "none",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      zIndex: 100,
+      boxShadow: "2px 2px 10px rgba(0,0,0,0.5)",
+      ...style
+    });
+
+    // hide series color markers
+    const idents = legendEl.querySelectorAll(".u-marker");
+
+    for (let i = 0; i < idents.length; i++)
+      idents[i].style.display = "none";
+
+    const overEl = u.root.querySelector(".u-over");
+    overEl.style.overflow = "visible";
+
+    // move legend into plot bounds
+    overEl.appendChild(legendEl);
+
+    // show/hide tooltip on enter/exit
+    overEl.addEventListener("mouseenter", () => {
+      legendEl.style.display = null;
+    });
+    overEl.addEventListener("mouseleave", () => {
+      legendEl.style.display = "none";
+    });
+
+    // let tooltip exit plot
+    //	overEl.style.overflow = "visible";
+  }
+
+  function update(u) {
+    const {
+      left,
+      top
+    } = u.cursor;
+    legendEl.style.transform = "translate(" + left + "px, " + top + "px)";
+  }
+
+  return {
+    hooks: {
+      init: init,
+      setCursor: update,
+    }
+  };
+}
+
+function boxesPlugin({
+  gap = 2,
+  style = {
+    outlineColor: "#000000",
+    fillColor: "#eee"
+  },
+  bodyWidthFactor = 0.7,
+  shadowWidth = 2,
+  bodyOutline = 1
+} = {}) {
+
+  function drawBoxes(u) {
+    u.ctx.save();
+
+    const offset = (shadowWidth % 2) / 2;
+
+    u.ctx.translate(offset, offset);
+
+    for (let i = u.scales.x.min; i <= u.scales.x.max; i++) {
+      let med = u.data[1][i];
+      let q1 = u.data[2][i];
+      let q3 = u.data[3][i];
+      let min = u.data[4][i];
+      let max = u.data[5][i];
+
+      let timeAsX = u.valToPos(i, "x", true);
+      if (isNaN(timeAsX)) {
+        // compensate when only one tag in measurements, redraw at center
+        timeAsX = (u.width * devicePixelRatio) / 2;
+      }
+      let lowAsY = u.valToPos(min, "y", true);
+      let highAsY = u.valToPos(max, "y", true);
+      let openAsY = u.valToPos(q1, "y", true);
+      let closeAsY = u.valToPos(q3, "y", true);
+      let medAsY = u.valToPos(med, "y", true);
+
+      // shadow rect
+      let shadowHeight = Math.max(highAsY, lowAsY) - Math.min(highAsY, lowAsY);
+      let shadowX = timeAsX;
+      let shadowY = Math.min(highAsY, lowAsY);
+
+      u.ctx.beginPath();
+      u.ctx.setLineDash([4, 4]);
+      u.ctx.lineWidth = shadowWidth;
+      u.ctx.strokeStyle = style.outlineColor;
+      u.ctx.moveTo(
+        Math.round(shadowX),
+        Math.round(shadowY),
+      );
+      u.ctx.lineTo(
+        Math.round(shadowX),
+        Math.round(shadowY + shadowHeight),
+      );
+      u.ctx.stroke();
+
+      // body rect
+      // when min = max again compensate
+      let divisor = u.scales.x.max == u.scales.x.min ? 3 : (u.scales.x.max - u.scales.x.min)
+      let columnWidth = u.bbox.width / divisor;
+      let bodyWidth = Math.round(bodyWidthFactor * (columnWidth - gap));
+      let bodyHeight = Math.max(closeAsY, openAsY) - Math.min(closeAsY, openAsY);
+      let bodyX = timeAsX - (bodyWidth / 2);
+      let bodyY = Math.min(closeAsY, openAsY);
+
+      u.ctx.fillStyle = style.fillColor;
+      u.ctx.fillRect(
+        Math.round(bodyX),
+        Math.round(bodyY),
+        Math.round(bodyWidth),
+        Math.round(bodyHeight),
+      );
+
+      u.ctx.fillStyle = style.fillColor;
+      u.ctx.fillRect(
+        Math.round(bodyX + bodyOutline),
+        Math.round(bodyY + bodyOutline),
+        Math.round(bodyWidth - bodyOutline * 2),
+        Math.round(bodyHeight - bodyOutline * 2),
+      );
+
+      // median
+      u.ctx.fillStyle = style.outlineColor;
+      u.ctx.fillRect(
+        Math.round(bodyX),
+        Math.round(medAsY - 1),
+        Math.round(bodyWidth),
+        Math.round(2),
+      );
+
+      // hz min/max whiskers
+      u.ctx.beginPath();
+      u.ctx.setLineDash([]);
+      u.ctx.lineWidth = shadowWidth;
+      u.ctx.strokeStyle = style.outlineColor;
+      u.ctx.moveTo(
+        Math.round(bodyX),
+        Math.round(highAsY),
+      );
+      u.ctx.lineTo(
+        Math.round(bodyX + bodyWidth),
+        Math.round(highAsY),
+      );
+      u.ctx.moveTo(
+        Math.round(bodyX),
+        Math.round(lowAsY),
+      );
+      u.ctx.lineTo(
+        Math.round(bodyX + bodyWidth),
+        Math.round(lowAsY),
+      );
+      u.ctx.stroke();
+
+    }
+
+    u.ctx.translate(-offset, -offset);
+
+    u.ctx.restore();
+  }
+
+  return {
+    opts: (u, opts) => {
+      uPlot.assign(opts, {
+        cursor: {
+          points: {
+            show: false,
+          }
+        }
+      });
+
+      opts.series.forEach(series => {
+        series.paths = () => null;
+        series.points = {
+          show: false
+        };
+      });
+    },
+    hooks: {
+      draw: drawBoxes,
+    }
+  };
+}
+
+export default {
+  plugins(options = {}) {
+    return [
+      columnHighlightPlugin(options.columnHighlightPlugin),
+      legendAsTooltipPlugin(options.legendAsTooltipPlugin),
+      boxesPlugin(options.boxesPlugin)
+    ]
+  }
+}

--- a/assets/js/metrics_live/charts/distribution/statistics.js
+++ b/assets/js/metrics_live/charts/distribution/statistics.js
@@ -1,0 +1,79 @@
+// ported from https://stackoverflow.com/questions/14683467/finding-the-first-and-third-quartiles/51264621#51264621
+function percentile(arr, p) {
+  // algo derived from Aczel pg 15 bottom
+  if (p >= 1)
+    return arr[arr.length - 1];
+
+  let left = 0,
+    right = 0;
+
+  let n = p * (arr.length - 1) + 1;
+
+  let pos = p * (arr.length + 1);
+
+  if (pos >= 1) {
+    left = arr[Math.floor(n) - 1];
+    right = arr[Math.floor(n)];
+  } else {
+    left = arr[0];
+    right = arr[1];
+  }
+
+  if (left == right)
+    return left;
+
+  let part = n - Math.floor(n);
+
+  return left + part * (right - left);
+}
+
+function geoMean(arr) {
+  let logSum = arr.reduce((acc, val) => acc + Math.log(val), 0);
+  return Math.exp(logSum / arr.length);
+}
+
+function calculateStatistics(arr) {
+  arr = arr.slice().sort((a, b) => a - b);
+  var n = arr.length;
+  var sum = arr.reduce((acc, val) => acc + val, 0);
+  //	var prod = arr.reduce((acc, val) => acc * val, 1);
+  var amean = sum / n;
+  //	var gmean = Math.pow(prod, 1 / n);
+  var gmean = geoMean(arr);
+  //	var median = n % 2 === 0 ? (arr[n / 2 - 1] + arr[n / 2]) / 2 : arr[(n - 1) / 2];
+  var median = percentile(arr, 0.5);
+  var q1 = percentile(arr, 0.25);
+  var q3 = percentile(arr, 0.75);
+  var variance = 0;
+  var stddev = 0;
+
+  var v1 = 0,
+    v2 = 0;
+
+  for (var i = 0; i < n; i++) {
+    var dMean = arr[i] - amean;
+    v1 += Math.pow(dMean, 2);
+    v2 += dMean;
+  }
+
+  v2 *= v2 / n;
+  variance = Math.max((v1 - v2) / (n - 1), 0);
+  stddev = Math.sqrt(variance);
+
+  return {
+    count: n,
+    min: Math.min.apply(Math, arr),
+    max: Math.max.apply(Math, arr),
+    sum: sum,
+    median: median,
+    q1: q1,
+    q3: q3,
+    //	iq: +(q3 - q1),
+    amean: amean,
+    gmean: gmean,
+    variance: variance,
+    stddev: stddev,
+  };
+}
+
+export default calculateStatistics

--- a/assets/js/metrics_live/color_wheel.js
+++ b/assets/js/metrics_live/color_wheel.js
@@ -25,7 +25,8 @@ export const LineColor = {
     const [r, g, b] = ColorWheel.rgb(i)
     return {
       stroke: `rgb(${r}, ${g}, ${b})`,
-      fill: `rgb(${r}, ${g}, ${b}, 0.1)`
+      fill: `rgb(${r}, ${g}, ${b}, 0.1)`,
+      overlay: `rgb(${r}, ${g}, ${b}, 0.9)`
     }
   }
 }

--- a/assets/js/metrics_live/index.js
+++ b/assets/js/metrics_live/index.js
@@ -1,6 +1,7 @@
 import { ColorWheel, LineColor } from './color_wheel'
 import _css from 'uplot/dist/uPlot.min.css'
 import uPlot from 'uplot'
+import Distribution from './charts/distribution'
 
 const SeriesValue = (options) => {
   if (!options.unit) return {}
@@ -374,7 +375,8 @@ const __METRICS__ = {
   counter: CommonMetric,
   last_value: CommonMetric,
   sum: CommonMetric,
-  summary: Summary
+  summary: Summary,
+  distribution: Distribution
 }
 
 export class TelemetryChart {
@@ -388,6 +390,9 @@ export class TelemetryChart {
     const metric = __METRICS__[options.metric]
     if (metric === Summary) {
       this.metric = new Summary(options, chartEl)
+      this.uplotChart = this.metric.chart
+    } else if (metric === Distribution){
+      this.metric = new Distribution(options, chartEl)
       this.uplotChart = this.metric.chart
     } else {
       this.uplotChart = new uPlot(metric.getConfig(options), metric.initialData(options), chartEl)

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,7 +18,7 @@
     "phoenix": "../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view",
-    "uplot": "^1.0.11"
+    "uplot": "^1.6.4"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",

--- a/lib/phoenix/live_dashboard/components/chart_component.ex
+++ b/lib/phoenix/live_dashboard/components/chart_component.ex
@@ -73,9 +73,7 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   defp chart_kind(Telemetry.Metrics.LastValue), do: :last_value
   defp chart_kind(Telemetry.Metrics.Sum), do: :sum
   defp chart_kind(Telemetry.Metrics.Summary), do: :summary
-
-  defp chart_kind(Telemetry.Metrics.Distribution),
-    do: raise(ArgumentError, "LiveDashboard does not yet support distribution metrics")
+  defp chart_kind(Telemetry.Metrics.Distribution), do: :distribution
 
   defp chart_label(%{} = metric) do
     metric.name


### PR DESCRIPTION
Hi all, I decided to give https://github.com/phoenixframework/phoenix_live_dashboard/issues/7 a shot, seeing as there doesn't seem to be any interest in tackling it right now. I went for box plots because they made more sense to me- although I'll be first to admit I know almost nothing about charts and statistics 🙂 

You can see a screenshot of how the end result looks here

<img width="1146" alt="Screenshot 2021-02-14 at 17 58 02" src="https://user-images.githubusercontent.com/622973/107882135-60ca2900-6ef0-11eb-913b-8f3372120118.png">

First chart is metric with one tag, second is with 2 tags and last one is without tags. You can see the code I used to generate and display test data in this gist https://gist.github.com/bottlenecked/6944746cf174f2cc0f6a2acbc0796102

This attempt heavily 'borrows' from @leeoniya's [box plot demo](https://leeoniya.github.io/uPlot/demos/box-whisker.html), wouldn't be able to pull this off without it.

Let me know if this is of interest and your suggestions on improvements- I'm sure I've missed a ton and would be happy to improve this PR