### PR TITLE
Remove duplication of page refresh

### DIFF
--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -87,9 +87,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   defp assign_refresh(socket) do
     module = socket.assigns.page.module
 
-    socket
-    |> update_menu(refresher?: module.__page_live__(:refresher?))
-    |> init_schedule_refresh()
+    update_menu(socket, refresher?: module.__page_live__(:refresher?))
   end
 
   defp init_schedule_refresh(socket) do


### PR DESCRIPTION
This commit fixes a bug in the init process of scheduling a page
refresh. The duplication was causing a strange behavior in pages
that rely on refresh.

PS 1: the refresh is being initialized at [line 53](https://github.com/philss/phoenix_live_dashboard/blob/68233b0465ef4213194ae674bf528804cdae6da8/lib/phoenix/live_dashboard/page_live.ex#L53)
PS 2: I'm not sure yet how to test this. Suggestions are welcome :)