### PR TITLE
Add missing component function list

### DIFF
--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -104,9 +104,8 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   ## Components
 
   A page can only have the components listed with this page.
-
-  Only `card/1`, `columns/1`, `fields_card/1`, `nav_bar/1`, `row/1`,
-  `shared_usage_card/1`, `table/1`, and `usage_card/1` are supported for now.
+  We currently support `card/1`, `columns/1`, `fields_card/1`, `nav_bar/1`,
+  `row/1`, `shared_usage_card/1`, `table/1`, and `usage_card/1`.
   """
 
   defstruct info: nil,

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -104,7 +104,9 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   ## Components
 
   A page can only have the components listed with this page.
-  At the moment, only `nav_bar/1` and `table/1` are supported.
+
+  Only `card/1`, `columns/1`, `fields_card/1`, `nav_bar/1`, `row/1`,
+  `shared_usage_card/1`, `table/1`, and `usage_card/1` are supported for now.
   """
 
   defstruct info: nil,


### PR DESCRIPTION
This add all missing component function list within a page builder in
the doc.