### PR TITLE
Add Github Action badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Phoenix LiveDashboard
 
+[![CI](https://github.com/phoenixframework/phoenix_live_dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/phoenixframework/phoenix_live_dashboard/actions/workflows/ci.yml)
+
 [Online Documentation](https://hexdocs.pm/phoenix_live_dashboard).
 
 <!-- MDOC !-->


### PR DESCRIPTION
Follow other projects within Phoenix framework repo, add the default
GitHub Action badge to show latest CI status.