### PR TITLE
Improve clarify and style

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -50,7 +50,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
   defp normalize_column(column) do
     case Access.fetch(column, :field) do
       {:ok, nil} ->
-        msg = "expected :field parameter to not be nil, column received: #{inspect(column)}"
+        msg = "expected :field parameter not to be nil, column received: #{inspect(column)}"
         raise ArgumentError, msg
 
       {:ok, field} when is_atom(field) or is_binary(field) ->

--- a/test/phoenix/live_dashboard/components/table_component_test.exs
+++ b/test/phoenix/live_dashboard/components/table_component_test.exs
@@ -195,7 +195,7 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
         })
       end
 
-      msg = "expected :field parameter to not be nil, column received: [field: nil]"
+      msg = "expected :field parameter not to be nil, column received: [field: nil]"
 
       assert_raise ArgumentError, msg, fn ->
         TableComponent.normalize_params(%{


### PR DESCRIPTION
"To be, or NOT to be" is preferable to "to be, or to NOT be".