### PR TITLE
Give proper message when missing :sortable param in columns

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -20,6 +20,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
     params
     |> validate_required([:columns, :id, :row_fetcher, :title])
     |> normalize_columns()
+    |> validate_required_one_sortable_column()
     |> Map.put_new(:search, true)
     |> Map.put_new(:limit, @limit)
     |> Map.put_new(:row_attrs, [])
@@ -69,6 +70,16 @@ defmodule Phoenix.LiveDashboard.TableComponent do
       :error ->
         msg = "expected :field parameter to be received, column received: #{inspect(column)}"
         raise ArgumentError, msg
+    end
+  end
+
+  defp validate_required_one_sortable_column(%{columns: columns} = params) do
+    sortable_columns = sortable_columns(columns)
+
+    if sortable_columns == [] do
+      raise ArgumentError, "expect at least one column has :sortable parameter"
+    else
+      params
     end
   end
 

--- a/test/phoenix/live_dashboard/components/table_component_test.exs
+++ b/test/phoenix/live_dashboard/components/table_component_test.exs
@@ -217,12 +217,23 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
         })
       end
 
+      msg = "expect at least one column has :sortable parameter"
+
+      assert_raise ArgumentError, msg, fn ->
+        TableComponent.normalize_params(%{
+          title: "title",
+          row_fetcher: &row_fetcher/2,
+          id: "id",
+          columns: [[field: "id"]]
+        })
+      end
+
       assert params =
                TableComponent.normalize_params(%{
                  title: "title",
                  row_fetcher: &row_fetcher/2,
                  id: "id",
-                 columns: [[field: "id"]]
+                 columns: [[field: "id", sortable: "asc"], [field: "id2"]]
                })
 
       assert [
@@ -232,11 +243,20 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
                  format: format_fun,
                  header: "Id",
                  header_attrs: [],
+                 sortable: "asc"
+               },
+               %{
+                 cell_attrs: [],
+                 field: "id2",
+                 format: format_fun,
+                 header: "Id2",
+                 header_attrs: [],
                  sortable: nil
                }
              ] = params.columns
 
       assert "id" = format_fun.("id")
+      assert "id2" = format_fun.("id2")
     end
 
     test "adds default values" do
@@ -255,7 +275,7 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
                  title: "title",
                  row_fetcher: &row_fetcher/2,
                  id: "id",
-                 columns: [[field: :id]]
+                 columns: [[field: :id, sortable: "asc"]]
                })
 
       assert is_function(fun, 2)


### PR DESCRIPTION
When missing at least one column with :sortable param in :column field
of TableComponent, the raised exception did not give explicit message on
such requirement. This PR adds that requirement in the raised exception
message.

Before:
![image](https://user-images.githubusercontent.com/134518/117453237-49db2600-af77-11eb-8a08-423ba44c7a5b.png)

After:
![image](https://user-images.githubusercontent.com/134518/117453262-53648e00-af77-11eb-81af-2516e7e85407.png)
