### PR TITLE
Revise missing usages fields in shared card component

### DIFF
--- a/lib/phoenix/live_dashboard/components/shared_usage_card_component.ex
+++ b/lib/phoenix/live_dashboard/components/shared_usage_card_component.ex
@@ -18,21 +18,25 @@ defmodule Phoenix.LiveDashboard.SharedUsageCardComponent do
   defp validate_usages(params = %{usages: usages}) do
     normalized_usages =
       Enum.map(usages, fn usage ->
-        validate_required(usage, [:data, :dom_sub_id])
+        validate_required(usage, [:data, :dom_sub_id], :usages)
         put_usage_defaults(usage)
       end)
 
     %{params | usages: normalized_usages}
   end
 
-  defp validate_required(params, list) do
+  defp validate_required(params, list, parent_key \\ false) do
     case Enum.find(list, &(not Map.has_key?(params, &1))) do
       nil ->
         :ok
 
       key ->
-        raise ArgumentError,
-              "the #{inspect(key)} parameter is expected in shared usage card component"
+        msg =
+          if parent_key,
+            do: "parent #{inspect(parent_key)} parameter of shared usage card component",
+            else: "shared usage card component"
+
+        raise ArgumentError, "the #{inspect(key)} parameter is expected in #{msg}"
     end
 
     params

--- a/test/phoenix/live_dashboard/components/shared_usage_card_component_test.exs
+++ b/test/phoenix/live_dashboard/components/shared_usage_card_component_test.exs
@@ -51,7 +51,8 @@ defmodule Phoenix.LiveDashboard.SharedUsageCardComponentTest do
     end
 
     test "validates required params in :usages field" do
-      msg = "the :data parameter is expected in shared usage card component"
+      msg =
+        "the :data parameter is expected in parent :usages parameter of shared usage card component"
 
       assert_raise ArgumentError, msg, fn ->
         SharedUsageCardComponent.normalize_params(%{
@@ -63,7 +64,8 @@ defmodule Phoenix.LiveDashboard.SharedUsageCardComponentTest do
         })
       end
 
-      msg = "the :dom_sub_id parameter is expected in shared usage card component"
+      msg =
+        "the :dom_sub_id parameter is expected in parent :usages parameter of shared usage card component"
 
       assert_raise ArgumentError, msg, fn ->
         SharedUsageCardComponent.normalize_params(%{


### PR DESCRIPTION
This PR revises the raised exception message to be more explicit in
which required field in missing in the parent :usages field.