### PR TITLE
Validate required field for fields card component

### DIFF
--- a/lib/phoenix/live_dashboard/components/fields_card_component.ex
+++ b/lib/phoenix/live_dashboard/components/fields_card_component.ex
@@ -8,12 +8,24 @@ defmodule Phoenix.LiveDashboard.FieldsCardComponent do
 
   def normalize_params(params) do
     params
+    |> validate_required([:fields])
     |> put_defaults()
+  end
+
+  defp validate_required(params, list) do
+    case Enum.find(list, &(not Map.has_key?(params, &1))) do
+      nil ->
+        :ok
+
+      key ->
+        raise ArgumentError, "the #{inspect(key)} parameter is expected in fields card component"
+    end
+
+    params
   end
 
   defp put_defaults(params) do
     params
-    |> Map.put_new(:fields, [])
     |> Map.put_new(:title, nil)
     |> Map.put_new(:inner_title, nil)
     |> Map.put_new(:hint, nil)

--- a/test/phoenix/live_dashboard/components/fields_card_component_test.exs
+++ b/test/phoenix/live_dashboard/components/fields_card_component_test.exs
@@ -1,0 +1,15 @@
+defmodule Phoenix.LiveDashboard.FieldsCardComponentTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.LiveDashboard.FieldsCardComponent
+
+  describe "normalize_params/1" do
+    test "validates required params" do
+      msg = "the :fields parameter is expected in fields card component"
+
+      assert_raise ArgumentError, msg, fn ->
+        FieldsCardComponent.normalize_params(%{})
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the missing validation for required `:fields` field in fields
card component which supposed to match requirement in the doc.