### PR TITLE
Update fields card component code example

### DIFF
--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -364,7 +364,6 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
         fields_card(
           title: "Run queues",
           inner_title: "Total",
-          class: "additional-class",
           fields: ["USER": "...", "ROOTDIR: "..."]
         )
       end


### PR DESCRIPTION
This PR removes the incorrect code example which showing the non exists
`:class` option.