### PR TITLE
fix: remove live_component warning

### DIFF
--- a/lib/phoenix/live_dashboard/components/columns_component.ex
+++ b/lib/phoenix/live_dashboard/components/columns_component.ex
@@ -51,14 +51,14 @@ defmodule Phoenix.LiveDashboard.ColumnsComponent do
   defp render_component(components, assigns) when is_list(components) do
     ~L"""
     <%= for {component_module, component_params} <- components do %>
-      <%= live_component @socket, component_module, component_params %>
+      <%= live_component component_module, component_params %>
     <% end %>
     """
   end
 
   defp render_component({component_module, component_params}, assigns) do
     ~L"""
-      <%= live_component @socket, component_module, component_params %>
+      <%= live_component component_module, component_params %>
     """
   end
 end

--- a/lib/phoenix/live_dashboard/components/row_component.ex
+++ b/lib/phoenix/live_dashboard/components/row_component.ex
@@ -42,7 +42,7 @@ defmodule Phoenix.LiveDashboard.RowComponent do
     ~L"""
     <div class="row">
       <%= for {component_module, component_params} <- @components do %>
-        <%= live_component @socket, component_module, component_params %>
+        <%= live_component component_module, component_params %>
       <% end %>
     </div>
     """

--- a/lib/phoenix/live_dashboard/info/modal_component.ex
+++ b/lib/phoenix/live_dashboard/info/modal_component.ex
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveDashboard.ModalComponent do
             <%= live_patch raw("&times;"), to: @return_to, class: "close" %>
           </div>
           <div class="modal-body">
-            <%= live_component @socket, @component, @opts %>
+            <%= live_component @component, @opts %>
           </div>
         </div>
       </div>

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -73,7 +73,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
       <%= if @metrics do %>
         <div class="phx-dashboard-metrics-grid row">
         <%= for {metric, id} <- @metrics do %>
-          <%= live_component @socket, ChartComponent, id: id, metric: metric %>
+          <%= live_component ChartComponent, id: id, metric: metric %>
         <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
fix for warning:
```elixir
warning: passing the @socket to live_component is no longer necessary, please remove the socket argument
```