### PR TITLE
Test for columns type exception

### DIFF
--- a/test/phoenix/live_dashboard/components/table_component_test.exs
+++ b/test/phoenix/live_dashboard/components/table_component_test.exs
@@ -228,6 +228,17 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
         })
       end
 
+      msg = ":columns must be a list, got: nil"
+
+      assert_raise ArgumentError, msg, fn ->
+        TableComponent.normalize_params(%{
+          title: "title",
+          row_fetcher: &row_fetcher/2,
+          id: "id",
+          columns: nil
+        })
+      end
+
       assert params =
                TableComponent.normalize_params(%{
                  title: "title",


### PR DESCRIPTION
This PR adds the missing test for `:columns` type exception in table
component.