### PR TITLE
Test for not supported distribution metric

### DIFF
--- a/lib/phoenix/live_dashboard/components/chart_component.ex
+++ b/lib/phoenix/live_dashboard/components/chart_component.ex
@@ -75,7 +75,7 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   defp chart_kind(Telemetry.Metrics.Summary), do: :summary
 
   defp chart_kind(Telemetry.Metrics.Distribution),
-    do: raise(ArgumentError, "LiveDashboard does not yet support distribution metrics")
+    do: raise(ArgumentError, "distribution metrics is not yet supported in chart component")
 
   defp chart_label(%{} = metric) do
     metric.name

--- a/test/phoenix/live_dashboard/components/chart_component_test.exs
+++ b/test/phoenix/live_dashboard/components/chart_component_test.exs
@@ -33,6 +33,14 @@ defmodule Phoenix.LiveDashboard.ChartComponentTest do
       assert result =~ ~s|data-title="a.b.c.count"|
     end
 
+    test "distribution metric" do
+      msg = "distribution metrics is not yet supported in chart component"
+
+      assert_raise ArgumentError, msg, fn ->
+        render_chart(metric: distribution([:a, :b, :c, :count]))
+      end
+    end
+
     test "adds units" do
       result = render_chart(metric: last_value([:a, :b, :c, :size], unit: :megabyte))
       assert result =~ ~s|data-unit="MB"|


### PR DESCRIPTION
This PR adds test case for not supported telemetry distribution metric
in chart component.