### PR TITLE
Adds reductions diff column in process page

### DIFF
--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -104,9 +104,11 @@ defmodule Phoenix.LiveDashboard.TableComponent do
     {rows, total, socket}
   end
 
-  defp fetch_rows(row_fetcher, table_params, page_node, socket)
+  defp fetch_rows({row_fetcher, initial_state}, table_params, page_node, socket)
        when is_function(row_fetcher, 3) do
-    row_fetcher.(table_params, page_node, socket)
+    state = Map.get(socket.assigns, :row_fetcher_state, initial_state)
+    {rows, total, state} = row_fetcher.(table_params, page_node, state)
+    {rows, total, assign(socket, :row_fetcher_state, state)}
   end
 
   defp normalize_table_params(assigns) do

--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -93,9 +93,20 @@ defmodule Phoenix.LiveDashboard.TableComponent do
       row_fetcher: row_fetcher
     } = assigns
 
-    {rows, total} = row_fetcher.(table_params, page.node)
+    {rows, total, socket} = fetch_rows(row_fetcher, table_params, page.node, socket)
     assigns = Map.merge(assigns, %{rows: rows, total: total})
     {:ok, assign(socket, assigns)}
+  end
+
+  defp fetch_rows(row_fetcher, table_params, page_node, socket)
+       when is_function(row_fetcher, 2) do
+    {rows, total} = row_fetcher.(table_params, page_node)
+    {rows, total, socket}
+  end
+
+  defp fetch_rows(row_fetcher, table_params, page_node, socket)
+       when is_function(row_fetcher, 3) do
+    row_fetcher.(table_params, page_node, socket)
   end
 
   defp normalize_table_params(assigns) do

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -247,7 +247,10 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
     * `:row_fetcher` - Required. A function which receives the params and the node and
       returns a tuple with the rows and the total number:
-      `(params(), node()) -> {list(), integer() | binary()}`
+      ```
+      (params(), node()) -> {list(), integer() | binary()} |
+        (params(), node(), socket()) -> {list(), integer() | binary(), socket()}
+      ```
 
     * `:rows_name` - A string to name the representation of the rows.
       Default is calculated from the current page.

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -247,10 +247,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
     * `:row_fetcher` - Required. A function which receives the params and the node and
       returns a tuple with the rows and the total number:
-      ```
-      (params(), node()) -> {list(), integer() | binary()} |
-        (params(), node(), socket()) -> {list(), integer() | binary(), socket()}
-      ```
+      `(params(), node()) -> {list(), integer() | binary()}`
+      Optionally, if the function needs to keep a state, it can be defined as a tuple
+      with the first element a function and the second the initial state. In this case,
+      the function will also receive a third argument which is the state, and it will return
+      a tuple with the rows, the total number and the new state for the following call:
+      `{(params(), node(), term()) -> {list(), integer() | binary(), term()}, term()}`
 
     * `:rows_name` - A string to name the representation of the rows.
       Default is calculated from the current page.

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -249,7 +249,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
       returns a tuple with the rows and the total number:
       `(params(), node()) -> {list(), integer() | binary()}`
       Optionally, if the function needs to keep a state, it can be defined as a tuple
-      with the first element a function and the second the initial state. In this case,
+      where the first element a function and the second the initial state. In this case,
       the function will also receive a third argument which is the state, and it will return
       a tuple with the rows, the total number and the new state for the following call:
       `{(params(), node(), term()) -> {list(), integer() | binary(), term()}, term()}`

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -247,12 +247,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
     * `:row_fetcher` - Required. A function which receives the params and the node and
       returns a tuple with the rows and the total number:
-      `(params(), node()) -> {list(), integer() | binary()}`
+      `(params(), node() -> {list(), integer() | binary()})`.
       Optionally, if the function needs to keep a state, it can be defined as a tuple
-      where the first element a function and the second the initial state. In this case,
-      the function will also receive a third argument which is the state, and it will return
-      a tuple with the rows, the total number and the new state for the following call:
-      `{(params(), node(), term()) -> {list(), integer() | binary(), term()}, term()}`
+      where the first element is a function and the second is the initial state.
+      In this case, the function will receive the state as third argument and must return
+      a tuple with the rows, the total number, and the new state for the following call:
+      `{(params(), node(), term() -> {list(), integer() | binary(), term()}), term()}`
 
     * `:rows_name` - A string to name the representation of the rows.
       Default is calculated from the current page.

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -13,15 +13,21 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
       columns: table_columns(),
       id: @table_id,
       row_attrs: &row_attrs/1,
-      row_fetcher: &fetch_processes/2,
+      row_fetcher: &fetch_processes/3,
       title: "Processes"
     )
   end
 
-  defp fetch_processes(params, node) do
+  defp fetch_processes(params, node, socket) do
     %{search: search, sort_by: sort_by, sort_dir: sort_dir, limit: limit} = params
 
-    SystemInfo.fetch_processes(node, search, sort_by, sort_dir, limit)
+    prev_run = socket.assigns[:prev_run]
+
+    {processes, count, prev_run} =
+      SystemInfo.fetch_processes(node, search, sort_by, sort_dir, limit, prev_run)
+
+    socket = assign(socket, prev_run: prev_run)
+    {processes, count, socket}
   end
 
   defp table_columns() do
@@ -49,6 +55,13 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
       %{
         field: :reductions,
         header: "Reductions",
+        header_attrs: [class: "text-right"],
+        cell_attrs: [class: "text-right"],
+        sortable: :desc
+      },
+      %{
+        field: :reductions_diff,
+        header: "Reductions Diff.",
         header_attrs: [class: "text-right"],
         cell_attrs: [class: "text-right"],
         sortable: :desc

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -13,21 +13,18 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
       columns: table_columns(),
       id: @table_id,
       row_attrs: &row_attrs/1,
-      row_fetcher: &fetch_processes/3,
+      row_fetcher: {&fetch_processes/3, nil},
       title: "Processes"
     )
   end
 
-  defp fetch_processes(params, node, socket) do
+  defp fetch_processes(params, node, state) do
     %{search: search, sort_by: sort_by, sort_dir: sort_dir, limit: limit} = params
 
-    prev_run = socket.assigns[:prev_run]
+    {processes, count, state} =
+      SystemInfo.fetch_processes(node, search, sort_by, sort_dir, limit, state)
 
-    {processes, count, prev_run} =
-      SystemInfo.fetch_processes(node, search, sort_by, sort_dir, limit, prev_run)
-
-    socket = assign(socket, prev_run: prev_run)
-    {processes, count, socket}
+    {processes, count, state}
   end
 
   defp table_columns() do
@@ -53,15 +50,8 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
         format: &format_bytes/1
       },
       %{
-        field: :reductions,
-        header: "Reductions",
-        header_attrs: [class: "text-right"],
-        cell_attrs: [class: "text-right"],
-        sortable: :desc
-      },
-      %{
         field: :reductions_diff,
-        header: "Reductions Diff.",
+        header: "Reductions",
         header_attrs: [class: "text-right"],
         cell_attrs: [class: "text-right"],
         sortable: :desc

--- a/test/phoenix/live_dashboard/pages/processes_live_test.exs
+++ b/test/phoenix/live_dashboard/pages/processes_live_test.exs
@@ -64,16 +64,16 @@ defmodule Phoenix.LiveDashboard.ProcessesLiveTest do
 
     Agent.start_link(fn -> List.duplicate("a", 1000) end, name: :process_live_test_high_reductions)
 
-    {:ok, live, _} = live(build_conn(), processes_path(1000, "", :reductions, :desc))
+    {:ok, live, _} = live(build_conn(), processes_path(1000, "", :reductions_diff, :desc))
     rendered = render(live)
     assert rendered =~ ~r/:process_live_test_high_reductions.*:process_live_test_low_reductions/s
-    assert rendered =~ processes_href(1000, "", :reductions, :asc)
-    refute rendered =~ processes_href(1000, "", :reductions, :desc)
+    assert rendered =~ processes_href(1000, "", :reductions_diff, :asc)
+    refute rendered =~ processes_href(1000, "", :reductions_diff, :desc)
 
-    rendered = render_patch(live, processes_path(1000, "", :reductions, :asc))
+    rendered = render_patch(live, processes_path(1000, "", :reductions_diff, :asc))
     assert rendered =~ ~r/:process_live_test_low_reductions.*:process_live_test_high_reductions/s
-    assert rendered =~ processes_href(1000, "", :reductions, :desc)
-    refute rendered =~ processes_href(1000, "", :reductions, :asc)
+    assert rendered =~ processes_href(1000, "", :reductions_diff, :desc)
+    refute rendered =~ processes_href(1000, "", :reductions_diff, :asc)
   end
 
   test "order processes by message queue len" do

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -30,18 +30,26 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
 
   describe "processes" do
     test "all with limit" do
-      {processes, count} = SystemInfo.fetch_processes(node(), "", :memory, :asc, 5000)
+      {processes, count, _} = SystemInfo.fetch_processes(node(), "", :memory, :asc, 5000)
       assert Enum.count(processes) == count
-      {processes, count} = SystemInfo.fetch_processes(node(), "", :memory, :asc, 1)
+      {processes, count, _} = SystemInfo.fetch_processes(node(), "", :memory, :asc, 1)
       assert Enum.count(processes) == 1
       assert count > 1
     end
 
     test "all with search" do
-      {pids, _count} = SystemInfo.fetch_processes(node(), ":user", :memory, :asc, 100)
+      {pids, _count, _} = SystemInfo.fetch_processes(node(), ":user", :memory, :asc, 100)
       assert [[pid, name | _]] = pids
       assert pid == {:pid, Process.whereis(:user)}
       assert name == {:name_or_initial_call, ":user"}
+    end
+
+    test "allows previous reductions param" do
+      {_pids, _count, state} =
+        SystemInfo.fetch_processes(node(), ":user", :reductions_diff, :asc, 100)
+
+      {_pids, _count, _state} =
+        SystemInfo.fetch_processes(node(), ":user", :reductions_diff, :asc, 100, state)
     end
 
     test "info" do


### PR DESCRIPTION
Closes #247 

The observer has an option in the `View` menu to show the accumulated or the difference reductions. I opted for adding a new column "Reductions diff", but maybe the table is too cluttered now. We could include a checkbox similar to the observer behaviour, but it could complicate the solution.  What do you think?

Because to calculate the difference we need state (the previous reductions), I had to change the `fetch_rows/2` to receive a third argument, in this case the `socket`. However, I don't like the solution because the received `socket` is the table component one, not the `LiveView` page one. It works for now, but I'm sure it will bring some kind of confusion for future developers. I'm open to other solutions :)

Edit to add a screenshot:

![image](https://user-images.githubusercontent.com/1745859/120107129-12b7f900-c160-11eb-8975-9c60fb18425d.png)
