### PR TITLE
Make ecto stats configurable

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -392,7 +392,7 @@ defmodule DemoWeb.Router do
         style: :style_csp_nonce,
         script: :script_csp_nonce
       },
-      ecto_psql_extras_args: [
+      ecto_psql_extras_options: [
         long_running_queries: [threshold: "200 milliseconds"]
       ]
     )

--- a/dev.exs
+++ b/dev.exs
@@ -391,7 +391,10 @@ defmodule DemoWeb.Router do
         img: :img_csp_nonce,
         style: :style_csp_nonce,
         script: :script_csp_nonce
-      }
+      },
+      ecto_psql_extras_args: [
+        long_running_queries: [threshold: "200 milliseconds"]
+      ]
     )
   end
 

--- a/guides/ecto_stats.md
+++ b/guides/ecto_stats.md
@@ -30,7 +30,7 @@ You want to list all repositories that connect to distinct databases. For exampl
 
 If you want to disable the "Ecto Stats" option altogether, set `ecto_repos: []`.
 
-Some queries such as `long_running_queries` can be configured by passing an extra `ecto_psql_extras_args`,
+Some queries such as `long_running_queries` can be configured by passing an extra `ecto_psql_extras_options`,
 which is a keyword where:
 - each key is the name of the query
 - each value is itself a keyword to be passed as `args` to `EctoPSQLExtras`
@@ -40,10 +40,10 @@ For example, if you want to configure the threshold for `long_running_queries`:
 ```elixir
 live_dashboard "/dashboard",
   ecto_repos: [MyApp.Repo],
-  ecto_psql_extras_args: [long_running_queries: [threshold: "200 milliseconds"]]
+  ecto_psql_extras_options: [long_running_queries: [threshold: "200 milliseconds"]]
 ```
 
-See the [`ecto_psql_extras` documentation](https://hexdocs.pm/ecto_psql_extras/readme.html#usage) for more details.
+See the [`ecto_psql_extras` documentation](https://hexdocs.pm/ecto_psql_extras/readme.html#usage) for available options.
 
 ### Install custom extensions
 

--- a/guides/ecto_stats.md
+++ b/guides/ecto_stats.md
@@ -6,7 +6,7 @@ This guide covers how to configure the LiveDashboard to show stats from your und
 
 To enable the "Ecto Stats" functionality in your dashboard, you will need to do the three steps below:
 
-  1. Add the ecto_psql_extras dependency
+  1. Add the [`ecto_psql_extras`](https://hexdocs.pm/ecto_psql_extras) dependency
   2. Configure the dashboard
   3. (optional) Install custom extensions
 
@@ -29,6 +29,21 @@ live_dashboard "/dashboard", ecto_repos: [MyApp.Repo]
 You want to list all repositories that connect to distinct databases. For example, if you have both `MyApp.Repo` and `MyApp.RepoAnother` but they connect to the same database, there is no benefit in listing both. Remember only Ecto repositories running on `Ecto.Adapters.Postgres` are currently supported.
 
 If you want to disable the "Ecto Stats" option altogether, set `ecto_repos: []`.
+
+Some queries such as `long_running_queries` can be configured by passing an extra `ecto_psql_extras_args`,
+which is a keyword where:
+- each key is the name of the query
+- each value is itself a keyword to be passed as `args` to `EctoPSQLExtras`
+
+For example, if you want to configure the threshold for `long_running_queries`:
+
+```elixir
+live_dashboard "/dashboard",
+  ecto_repos: [MyApp.Repo],
+  ecto_psql_extras_args: [long_running_queries: [threshold: "200 milliseconds"]]
+```
+
+See the [`ecto_psql_extras` documentation](https://hexdocs.pm/ecto_psql_extras/readme.html#usage) for more details.
 
 ### Install custom extensions
 

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -6,12 +6,19 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   @disabled_link "https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html"
 
   @impl true
-  def init(%{repo: nil}), do: {:ok, %{repo: nil}}
-  def init(%{repo: repo}), do: {:ok, %{repo: repo}, process: repo}
+  def init(%{repo: nil}), do: {:ok, %{repo: nil, ecto_args: []}}
+
+  def init(%{repo: repo, ecto_psql_extras_args: ecto_args}),
+    do: {:ok, %{repo: repo, ecto_args: ecto_args}, process: repo}
 
   @impl true
-  def mount(_params, %{repo: repo}, socket) do
-    {:ok, assign(socket, repo: repo, info_module: info_module_for(repo))}
+  def mount(_params, %{repo: repo, ecto_args: ecto_args}, socket) do
+    {:ok,
+     assign(socket,
+       repo: repo,
+       ecto_args: ecto_args,
+       info_module: info_module_for(repo)
+     )}
   end
 
   @impl true
@@ -54,16 +61,18 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
 
   @forbidden_tables [:kill_all, :mandelbrot]
 
-  defp items(%{repo: repo, info_module: info_module}) do
+  defp items(%{repo: repo, info_module: info_module, ecto_args: ecto_args}) do
     for {table_name, table_module} <- info_module.queries(repo),
         table_name not in @forbidden_tables do
       {table_name,
        name: Phoenix.Naming.humanize(table_name),
-       render: fn -> render_table(repo, info_module, table_name, table_module) end}
+       render: fn ->
+         render_table(repo, info_module, table_name, table_module, ecto_args)
+       end}
     end
   end
 
-  defp render_table(repo, info_module, table_name, table_module) do
+  defp render_table(repo, info_module, table_name, table_module, ecto_args) do
     info = table_module.info()
 
     columns =
@@ -82,7 +91,7 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
       search: searchable != [],
       columns: columns,
       rows_name: "entries",
-      row_fetcher: &row_fetcher(repo, info_module, table_name, searchable, &1, &2),
+      row_fetcher: &row_fetcher(repo, info_module, table_name, searchable, ecto_args, &1, &2),
       title: Phoenix.Naming.humanize(table_name)
     )
   end
@@ -90,8 +99,15 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   defp sortable(:string), do: :asc
   defp sortable(_), do: :desc
 
-  defp row_fetcher(repo, info_module, table_name, searchable, params, _node) do
-    %{columns: columns, rows: rows} = info_module.query(table_name, repo, format: :raw)
+  defp row_fetcher(repo, info_module, table_name, searchable, ecto_args, params, _node) do
+    opts =
+      case Keyword.fetch(ecto_args, table_name) do
+        {:ok, args} -> [args: args]
+        :error -> []
+      end
+      |> Keyword.merge(format: :raw)
+
+    %{columns: columns, rows: rows} = info_module.query(table_name, repo, opts)
 
     mapped =
       for row <- rows do

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -6,17 +6,17 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   @disabled_link "https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html"
 
   @impl true
-  def init(%{repo: nil}), do: {:ok, %{repo: nil, ecto_args: []}}
+  def init(%{repo: nil}), do: {:ok, %{repo: nil, ecto_options: []}}
 
-  def init(%{repo: repo, ecto_psql_extras_args: ecto_args}),
-    do: {:ok, %{repo: repo, ecto_args: ecto_args}, process: repo}
+  def init(%{repo: repo, ecto_psql_extras_options: ecto_options}),
+    do: {:ok, %{repo: repo, ecto_options: ecto_options}, process: repo}
 
   @impl true
-  def mount(_params, %{repo: repo, ecto_args: ecto_args}, socket) do
+  def mount(_params, %{repo: repo, ecto_options: ecto_options}, socket) do
     {:ok,
      assign(socket,
        repo: repo,
-       ecto_args: ecto_args,
+       ecto_options: ecto_options,
        info_module: info_module_for(repo)
      )}
   end
@@ -61,18 +61,18 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
 
   @forbidden_tables [:kill_all, :mandelbrot]
 
-  defp items(%{repo: repo, info_module: info_module, ecto_args: ecto_args}) do
+  defp items(%{repo: repo, info_module: info_module, ecto_options: ecto_options}) do
     for {table_name, table_module} <- info_module.queries(repo),
         table_name not in @forbidden_tables do
       {table_name,
        name: Phoenix.Naming.humanize(table_name),
        render: fn ->
-         render_table(repo, info_module, table_name, table_module, ecto_args)
+         render_table(repo, info_module, table_name, table_module, ecto_options)
        end}
     end
   end
 
-  defp render_table(repo, info_module, table_name, table_module, ecto_args) do
+  defp render_table(repo, info_module, table_name, table_module, ecto_options) do
     info = table_module.info()
 
     columns =
@@ -91,7 +91,7 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
       search: searchable != [],
       columns: columns,
       rows_name: "entries",
-      row_fetcher: &row_fetcher(repo, info_module, table_name, searchable, ecto_args, &1, &2),
+      row_fetcher: &row_fetcher(repo, info_module, table_name, searchable, ecto_options, &1, &2),
       title: Phoenix.Naming.humanize(table_name)
     )
   end
@@ -99,9 +99,9 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   defp sortable(:string), do: :asc
   defp sortable(_), do: :desc
 
-  defp row_fetcher(repo, info_module, table_name, searchable, ecto_args, params, _node) do
+  defp row_fetcher(repo, info_module, table_name, searchable, ecto_options, params, _node) do
     opts =
-      case Keyword.fetch(ecto_args, table_name) do
+      case Keyword.fetch(ecto_options, table_name) do
         {:ok, args} -> [args: args]
         :error -> []
       end

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -173,8 +173,8 @@ defmodule Phoenix.LiveDashboard.Router do
 
     ecto_repos = options[:ecto_repos]
 
-    ecto_psql_extras_args =
-      case options[:ecto_psql_extras_args] do
+    ecto_psql_extras_options =
+      case options[:ecto_psql_extras_options] do
         nil ->
           []
 
@@ -182,7 +182,7 @@ defmodule Phoenix.LiveDashboard.Router do
           unless Keyword.keyword?(args) and
                    args |> Keyword.values() |> Enum.all?(&Keyword.keyword?/1) do
             raise ArgumentError,
-                  ":ecto_psql_extras_args must be a keyword where each value is a keyword, got: " <>
+                  ":ecto_psql_extras_options must be a keyword where each value is a keyword, got: " <>
                     inspect(args)
           end
 
@@ -206,7 +206,7 @@ defmodule Phoenix.LiveDashboard.Router do
       additional_pages,
       request_logger_cookie_domain,
       ecto_repos,
-      ecto_psql_extras_args,
+      ecto_psql_extras_options,
       csp_nonce_assign_key
     ]
 
@@ -246,7 +246,7 @@ defmodule Phoenix.LiveDashboard.Router do
         additional_pages,
         request_logger_cookie_domain,
         ecto_repos,
-        ecto_psql_extras_args,
+        ecto_psql_extras_options,
         csp_nonce_assign_key
       ) do
     metrics_session = %{
@@ -271,7 +271,7 @@ defmodule Phoenix.LiveDashboard.Router do
         sockets: {Phoenix.LiveDashboard.SocketsPage, %{}},
         ets: {Phoenix.LiveDashboard.EtsPage, %{}}
       ]
-      |> Enum.concat(ecto_stats(ecto_repos, ecto_psql_extras_args))
+      |> Enum.concat(ecto_stats(ecto_repos, ecto_psql_extras_options))
       |> Enum.concat(additional_pages)
       |> Enum.map(fn {key, {module, opts}} ->
         {session, requirements} = initialize_page(module, opts)
@@ -294,7 +294,7 @@ defmodule Phoenix.LiveDashboard.Router do
   defp ecto_stats(nil, _),
     do: [{:ecto_stats, {Phoenix.LiveDashboard.EctoStatsPage, %{repo: nil}}}]
 
-  defp ecto_stats(repos, ecto_psql_extras_args) do
+  defp ecto_stats(repos, ecto_psql_extras_options) do
     for repo <- List.wrap(repos) do
       page =
         repo
@@ -305,7 +305,7 @@ defmodule Phoenix.LiveDashboard.Router do
 
       {page,
        {Phoenix.LiveDashboard.EctoStatsPage,
-        %{repo: repo, ecto_psql_extras_args: ecto_psql_extras_args}}}
+        %{repo: repo, ecto_psql_extras_options: ecto_psql_extras_options}}}
     end
   end
 

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -13,7 +13,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
     assert Router.__options__([]) == [
              session:
                {Phoenix.LiveDashboard.Router, :__session__,
-                [nil, false, nil, nil, [], nil, nil, nil]},
+                [nil, false, nil, nil, [], nil, nil, [], nil]},
              private: %{live_socket_path: "/live", csp_nonce_assign_key: nil},
              layout: {Phoenix.LiveDashboard.LayoutView, :dash},
              as: :live_dashboard
@@ -58,11 +58,11 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures metrics" do
     assert Router.__options__(metrics: Foo)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, {Foo, :metrics}, nil, [], nil, nil, nil]}
+              [nil, false, {Foo, :metrics}, nil, [], nil, nil, [], nil]}
 
     assert Router.__options__(metrics: {Foo, :bar})[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, {Foo, :bar}, nil, [], nil, nil, nil]}
+              [nil, false, {Foo, :bar}, nil, [], nil, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(metrics: [])
@@ -72,7 +72,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures env_keys" do
     assert Router.__options__(env_keys: ["USER", "ROOTDIR"])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [["USER", "ROOTDIR"], false, nil, nil, [], nil, nil, nil]}
+              [["USER", "ROOTDIR"], false, nil, nil, [], nil, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(env_keys: "FOO")
@@ -82,7 +82,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "accepts metrics_history option" do
     assert Router.__options__(metrics_history: {MyStorage, :metrics_history, []})[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, {MyStorage, :metrics_history, []}, [], nil, nil, nil]}
+              [nil, false, nil, {MyStorage, :metrics_history, []}, [], nil, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(metrics_history: %{namespace: {MyStorage, :metrics_history, []}})
@@ -96,15 +96,15 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures additional_pages" do
     assert Router.__options__(additional_pages: [])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [], nil, nil, nil]}
+              [nil, false, nil, nil, [], nil, nil, [], nil]}
 
     assert Router.__options__(additional_pages: [custom: CustomPage])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [custom: {CustomPage, []}], nil, nil, nil]}
+              [nil, false, nil, nil, [custom: {CustomPage, []}], nil, nil, [], nil]}
 
     assert Router.__options__(additional_pages: [custom: {CustomPage, [1]}])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [custom: {CustomPage, [1]}], nil, nil, nil]}
+              [nil, false, nil, nil, [custom: {CustomPage, [1]}], nil, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(additional_pages: [{CustomPage, 1}])
@@ -122,15 +122,15 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures cookie_domain" do
     assert Router.__options__(request_logger_cookie_domain: nil)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [], nil, nil, nil]}
+              [nil, false, nil, nil, [], nil, nil, [], nil]}
 
     assert Router.__options__(request_logger_cookie_domain: ".acme.com")[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [], ".acme.com", nil, nil]}
+              [nil, false, nil, nil, [], ".acme.com", nil, [], nil]}
 
     assert Router.__options__(request_logger_cookie_domain: :parent)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, false, nil, nil, [], :parent, nil, nil]}
+              [nil, false, nil, nil, [], :parent, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       Router.__options__(request_logger_cookie_domain: :unknown_atom)
@@ -138,6 +138,34 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
     assert_raise ArgumentError, fn ->
       Router.__options__(request_logger_cookie_domain: [])
+    end
+  end
+
+  test "configures ecto_psql_extras" do
+    assert Router.__options__(ecto_psql_extras_args: nil)[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, false, nil, nil, [], nil, nil, [], nil]}
+
+    assert Router.__options__(ecto_psql_extras_args: [])[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, false, nil, nil, [], nil, nil, [], nil]}
+
+    ecto_args = [long_running_queries: [threshold: "200 milliseconds"]]
+
+    assert Router.__options__(ecto_psql_extras_args: ecto_args)[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, false, nil, nil, [], nil, nil, ecto_args, nil]}
+
+    assert_raise ArgumentError, fn ->
+      Router.__options__(ecto_psql_extras_args: :not_a_list)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Router.__options__(ecto_psql_extras_args: [long_running_queries: :not_a_list])
+    end
+
+    assert_raise ArgumentError, fn ->
+      Router.__options__(ecto_psql_extras_args: [long_running_queries: [:not_a_keyword]])
     end
   end
 
@@ -164,7 +192,17 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                "requirements" => [{:application, :os_mon}]
              } =
                build_conn()
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, nil)
+               |> Phoenix.LiveDashboard.Router.__session__(
+                 [],
+                 false,
+                 [],
+                 [],
+                 [],
+                 nil,
+                 nil,
+                 [],
+                 nil
+               )
     end
 
     test "loads nonces when key present" do
@@ -175,7 +213,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                |> Plug.Conn.assign(:img_nonce, "img_nonce")
                |> Plug.Conn.assign(:style_nonce, "style_nonce")
                |> Plug.Conn.assign(:script_nonce, "script_nonce")
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, %{
+               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, [], %{
                  img: :img_nonce,
                  style: :style_nonce,
                  script: :script_nonce
@@ -187,7 +225,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                "csp_nonces" => %{img: nil, script: nil, style: nil}
              } =
                build_conn()
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, %{
+               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, [], %{
                  img: :img_nonce,
                  style: :style_nonce,
                  script: :script_nonce
@@ -202,13 +240,33 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                |> Plug.Conn.assign(:img_nonce, "img_nonce")
                |> Plug.Conn.assign(:style_nonce, "style_nonce")
                |> Plug.Conn.assign(:script_nonce, "script_nonce")
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, nil, nil)
+               |> Phoenix.LiveDashboard.Router.__session__(
+                 [],
+                 false,
+                 [],
+                 [],
+                 [],
+                 nil,
+                 nil,
+                 [],
+                 nil
+               )
     end
 
     test "generates additional pages per ecto repo" do
       assert %{"pages" => pages} =
                build_conn()
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, [], nil)
+               |> Phoenix.LiveDashboard.Router.__session__(
+                 [],
+                 false,
+                 [],
+                 [],
+                 [],
+                 nil,
+                 [],
+                 [],
+                 nil
+               )
 
       assert [ets: _] = Enum.take(pages, -1)
 
@@ -216,7 +274,17 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
       assert %{"pages" => pages} =
                build_conn()
-               |> Phoenix.LiveDashboard.Router.__session__([], false, [], [], [], nil, repos, nil)
+               |> Phoenix.LiveDashboard.Router.__session__(
+                 [],
+                 false,
+                 [],
+                 [],
+                 [],
+                 nil,
+                 repos,
+                 [],
+                 nil
+               )
 
       assert [
                ets: _,

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -142,30 +142,30 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   end
 
   test "configures ecto_psql_extras" do
-    assert Router.__options__(ecto_psql_extras_args: nil)[:session] ==
+    assert Router.__options__(ecto_psql_extras_options: nil)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
               [nil, false, nil, nil, [], nil, nil, [], nil]}
 
-    assert Router.__options__(ecto_psql_extras_args: [])[:session] ==
+    assert Router.__options__(ecto_psql_extras_options: [])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
               [nil, false, nil, nil, [], nil, nil, [], nil]}
 
     ecto_args = [long_running_queries: [threshold: "200 milliseconds"]]
 
-    assert Router.__options__(ecto_psql_extras_args: ecto_args)[:session] ==
+    assert Router.__options__(ecto_psql_extras_options: ecto_args)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
               [nil, false, nil, nil, [], nil, nil, ecto_args, nil]}
 
     assert_raise ArgumentError, fn ->
-      Router.__options__(ecto_psql_extras_args: :not_a_list)
+      Router.__options__(ecto_psql_extras_options: :not_a_list)
     end
 
     assert_raise ArgumentError, fn ->
-      Router.__options__(ecto_psql_extras_args: [long_running_queries: :not_a_list])
+      Router.__options__(ecto_psql_extras_options: [long_running_queries: :not_a_list])
     end
 
     assert_raise ArgumentError, fn ->
-      Router.__options__(ecto_psql_extras_args: [long_running_queries: [:not_a_keyword]])
+      Router.__options__(ecto_psql_extras_options: [long_running_queries: [:not_a_keyword]])
     end
   end
 


### PR DESCRIPTION
Hi! Thanks a lot for this project, we started using it to monitor our production servers and it is amazing :purple_heart:

We found ourselves wanting to tweak some of the configuration for the Ecto stats pages, but this seems not supported as of today.
After some investigation, it seems the underlying `EctoPSQLExtras` is supporting configuration but live dashboard isn't exposing this.

This PR is a proposal to enable forwarding args to  `EctoPSQLExtras`. What do you think?
![Screenshot from 2021-06-01 22-36-58](https://user-images.githubusercontent.com/11598866/120333376-97567300-c32a-11eb-881a-7370f2f94e8e.png)
