### PR TITLE
Move some helper functions to PageBuilder

### DIFF
--- a/lib/phoenix/live_dashboard/components/nav_bar_component.ex
+++ b/lib/phoenix/live_dashboard/components/nav_bar_component.ex
@@ -128,7 +128,7 @@ defmodule Phoenix.LiveDashboard.NavBarComponent do
   defp render_item_link(socket, page, item, current, id) do
     # The nav ignores all params, except the current node if any
     path =
-      Phoenix.LiveDashboard.Helpers.live_dashboard_path(
+      Phoenix.LiveDashboard.PageBuilder.live_dashboard_path(
         socket,
         page.route,
         page.node,

--- a/lib/phoenix/live_dashboard/components/nav_bar_component.ex
+++ b/lib/phoenix/live_dashboard/components/nav_bar_component.ex
@@ -127,7 +127,15 @@ defmodule Phoenix.LiveDashboard.NavBarComponent do
 
   defp render_item_link(socket, page, item, current, id) do
     # The nav ignores all params, except the current node if any
-    path = live_dashboard_path(socket, page.route, page.node, page.params, nav: id)
+    path =
+      Phoenix.LiveDashboard.Helpers.live_dashboard_path(
+        socket,
+        page.route,
+        page.node,
+        page.params,
+        nav: id
+      )
+
     class = "nav-link#{if current == id, do: " active"}"
 
     case item[:method] do

--- a/lib/phoenix/live_dashboard/components/table_component.ex
+++ b/lib/phoenix/live_dashboard/components/table_component.ex
@@ -1,6 +1,8 @@
 defmodule Phoenix.LiveDashboard.TableComponent do
   use Phoenix.LiveDashboard.Web, :live_component
 
+  alias Phoenix.LiveDashboard.PageBuilder
+
   @limit [50, 100, 500, 1000, 5000]
 
   @type params() :: %{
@@ -246,13 +248,13 @@ defmodule Phoenix.LiveDashboard.TableComponent do
   @impl true
   def handle_event("search", %{"search" => search}, socket) do
     table_params = %{socket.assigns.table_params | search: search}
-    to = live_dashboard_path(socket, socket.assigns.page, table_params)
+    to = PageBuilder.live_dashboard_path(socket, socket.assigns.page, table_params)
     {:noreply, push_patch(socket, to: to)}
   end
 
   def handle_event("select_limit", %{"limit" => limit}, socket) do
     table_params = %{socket.assigns.table_params | limit: limit}
-    to = live_dashboard_path(socket, socket.assigns.page, table_params)
+    to = PageBuilder.live_dashboard_path(socket, socket.assigns.page, table_params)
     {:noreply, push_patch(socket, to: to)}
   end
 
@@ -266,7 +268,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
         column
         |> column_header()
         |> sort_link_body(sort_dir)
-        |> live_patch(to: live_dashboard_path(socket, page, table_params))
+        |> live_patch(to: PageBuilder.live_dashboard_path(socket, page, table_params))
 
       %{} ->
         table_params = %{table_params | sort_dir: direction, sort_by: field}
@@ -274,7 +276,7 @@ defmodule Phoenix.LiveDashboard.TableComponent do
         column
         |> column_header()
         |> sort_link_body()
-        |> live_patch(to: live_dashboard_path(socket, page, table_params))
+        |> live_patch(to: PageBuilder.live_dashboard_path(socket, page, table_params))
     end
   end
 

--- a/lib/phoenix/live_dashboard/helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers.ex
@@ -1,6 +1,7 @@
 defmodule Phoenix.LiveDashboard.Helpers do
   @moduledoc false
 
+  alias Phoenix.LiveDashboard.PageBuilder
   import Phoenix.LiveView.Helpers
   @format_limit 100
 
@@ -20,69 +21,18 @@ defmodule Phoenix.LiveDashboard.Helpers do
   end
 
   @doc """
-  Computes a router path to the current page.
-  """
-  def live_dashboard_path(socket, %{route: route, node: node, params: params}) do
-    live_dashboard_path(socket, route, node, params, params)
-  end
-
-  @doc """
-  Computes a router path to the current page with merged params.
-  """
-  def live_dashboard_path(socket, %{route: route, node: node, params: old_params}, extra) do
-    new_params = Enum.into(extra, old_params, fn {k, v} -> {Atom.to_string(k), v} end)
-    live_dashboard_path(socket, route, node, old_params, new_params)
-  end
-
-  @doc """
-  Encodes Sockets for URLs.
-  """
-  def encode_socket(ref) do
-    '#Port' ++ rest = :erlang.port_to_list(ref)
-    "Socket#{rest}"
-  end
-
-  @doc """
-  Encodes ETSs for URLs.
-  """
-  def encode_ets(ref) do
-    '#Ref' ++ rest = :erlang.ref_to_list(ref)
-    "ETS#{rest}"
-  end
-
-  @doc """
-  Encodes PIDs for URLs.
-  """
-  def encode_pid(pid) do
-    "PID#{:erlang.pid_to_list(pid)}"
-  end
-
-  @doc """
-  Encodes Port for URLs.
-  """
-  def encode_port(port) when is_port(port) do
-    port
-    |> :erlang.port_to_list()
-    |> tl()
-    |> List.to_string()
-  end
-
-  @doc """
-  Encodes an application for URLs.
-  """
-  def encode_app(app) when is_atom(app) do
-    "App<#{app}>"
-  end
-
-  @doc """
   Formats any value.
   """
   def format_value(port, live_dashboard_path) when is_port(port) do
-    live_patch(inspect(port), to: live_dashboard_path.(node(port), info: encode_port(port)))
+    live_patch(inspect(port),
+      to: live_dashboard_path.(node(port), info: PageBuilder.encode_port(port))
+    )
   end
 
   def format_value(pid, live_dashboard_path) when is_pid(pid) do
-    live_patch(inspect(pid), to: live_dashboard_path.(node(pid), info: encode_pid(pid)))
+    live_patch(inspect(pid),
+      to: live_dashboard_path.(node(pid), info: PageBuilder.encode_pid(pid))
+    )
   end
 
   def format_value([_ | _] = list, live_dashboard_path) do

--- a/lib/phoenix/live_dashboard/helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers.ex
@@ -6,21 +6,6 @@ defmodule Phoenix.LiveDashboard.Helpers do
   @format_limit 100
 
   @doc """
-  Computes a route path to the given route, node, and params.
-  """
-  def live_dashboard_path(socket, route, node, old_params, new_params) when is_atom(node) do
-    apply(
-      socket.router.__helpers__(),
-      :live_dashboard_path,
-      if node == node() and is_nil(old_params["node"]) do
-        [socket, :page, route, new_params]
-      else
-        [socket, :page, node, route, new_params]
-      end
-    )
-  end
-
-  @doc """
   Formats any value.
   """
   def format_value(port, live_dashboard_path) when is_port(port) do

--- a/lib/phoenix/live_dashboard/info/app_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/app_info_component.ex
@@ -1,7 +1,7 @@
 defmodule Phoenix.LiveDashboard.AppInfoComponent do
   use Phoenix.LiveDashboard.Web, :live_component
 
-  alias Phoenix.LiveDashboard.{SystemInfo, ReingoldTilford}
+  alias Phoenix.LiveDashboard.{PageBuilder, SystemInfo, ReingoldTilford}
 
   @impl true
   def render(assigns) do
@@ -52,7 +52,7 @@ defmodule Phoenix.LiveDashboard.AppInfoComponent do
     end
   end
 
-  defp node_encoded_pid({_, pid, _}), do: encode_pid(pid)
+  defp node_encoded_pid({_, pid, _}), do: PageBuilder.encode_pid(pid)
 
   defp node_label({_, pid, []}), do: pid |> :erlang.pid_to_list() |> List.to_string()
   defp node_label({_, _, name}), do: inspect(name)

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -687,6 +687,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   @doc """
   Encodes Sockets for URLs.
+
+  ## Example
+
+  This function can be used to encode `@socket` for an event value:
+
+      <button phx-click="show-info" phx-value-info=<%= encode_socket(@socket) %>/>
   """
   @spec encode_socket(port()) :: binary()
   def encode_socket(ref) when is_port(ref) do
@@ -696,6 +702,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   @doc """
   Encodes ETSs references for URLs.
+
+  ## Example
+
+  This function can be used to encode an ETS reference for an event value:
+
+      <button phx-click="show-info" phx-value-info=<%= encode_ets(@reference) %>/>
   """
   @spec encode_ets(reference()) :: binary()
   def encode_ets(ref) when is_reference(ref) do
@@ -705,6 +717,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   @doc """
   Encodes PIDs for URLs.
+
+  ## Example
+
+  This function can be used to encode a PID for an event value:
+
+      <button phx-click="show-info" phx-value-info=<%= encode_pid(@pid) %>/>
   """
   @spec encode_pid(pid()) :: binary()
   def encode_pid(pid) when is_pid(pid) do
@@ -713,6 +731,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   @doc """
   Encodes Port for URLs.
+
+  ## Example
+
+  This function can be used to encode a Port for an event value:
+
+      <button phx-click="show-info" phx-value-info=<%= encode_port(@port) %>/>
   """
   @spec encode_port(port()) :: binary()
   def encode_port(port) when is_port(port) do
@@ -724,6 +748,12 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   @doc """
   Encodes an application for URLs.
+
+  ## Example
+
+  This function can be used to encode an application for an event value:
+
+      <button phx-click="show-info" phx-value-info=<%= encode_app(@my_app) %>/>
   """
   @spec encode_app(atom()) :: binary()
   def encode_app(app) when is_atom(app) do

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -211,8 +211,6 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   `Phoenix.LiveDashboard.PageBuilder`,
   but the `info` parameter (`phx-value-info`) needs to be encoded with
   one of the `encode_*` helper functions.
-  The events `select_node` and `select_refresh` are also handled
-  automatically by `Phoenix.LiveDashboard.PageBuilder`.
 
   For more details, see [`Phoenix.LiveView bindings`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-bindings)
   """

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -735,7 +735,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   """
   @spec live_dashboard_path(Socket.t(), page :: %__MODULE__{}) :: binary()
   def live_dashboard_path(socket, %{route: route, node: node, params: params}) do
-    Phoenix.LiveDashboard.Helpers.live_dashboard_path(socket, route, node, params, params)
+    live_dashboard_path(socket, route, node, params, params)
   end
 
   @doc """
@@ -744,7 +744,20 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   @spec live_dashboard_path(Socket.t(), page :: %__MODULE__{}, map()) :: binary()
   def live_dashboard_path(socket, %{route: route, node: node, params: old_params}, extra) do
     new_params = Enum.into(extra, old_params, fn {k, v} -> {Atom.to_string(k), v} end)
-    Phoenix.LiveDashboard.Helpers.live_dashboard_path(socket, route, node, old_params, new_params)
+    live_dashboard_path(socket, route, node, old_params, new_params)
+  end
+
+  @doc false
+  def live_dashboard_path(socket, route, node, old_params, new_params) when is_atom(node) do
+    apply(
+      socket.router.__helpers__(),
+      :live_dashboard_path,
+      if node == node() and is_nil(old_params["node"]) do
+        [socket, :page, route, new_params]
+      else
+        [socket, :page, node, route, new_params]
+      end
+    )
   end
 
   defmacro __using__(opts) do

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -210,7 +210,9 @@ defmodule Phoenix.LiveDashboard.PageLive do
   defp live_info(socket, %{info: title, node: node, params: params} = page) do
     if component = extract_info_component(title) do
       params = Map.delete(params, "info")
-      path = &live_dashboard_path(socket, page.route, &1, params, Enum.into(&2, params))
+
+      path =
+        &PageBuilder.live_dashboard_path(socket, page.route, &1, params, Enum.into(&2, params))
 
       live_modal(component,
         id: title,
@@ -264,7 +266,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
     page = socket.assigns.page
 
     if node && node != page.node do
-      to = live_dashboard_path(socket, page.route, node, page.params, page.params)
+      to = PageBuilder.live_dashboard_path(socket, page.route, node, page.params, page.params)
       {:noreply, push_redirect(socket, to: to)}
     else
       {:noreply, redirect_to_current_node(socket)}
@@ -295,7 +297,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
 
   defp maybe_link(socket, page, {:enabled, text, route}) do
     live_redirect(text,
-      to: live_dashboard_path(socket, route, page.node, page.params, []),
+      to: PageBuilder.live_dashboard_path(socket, route, page.node, page.params, []),
       class: "menu-item"
     )
   end
@@ -333,7 +335,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   end
 
   defp redirect_to_current_node(socket) do
-    push_redirect(socket, to: live_dashboard_path(socket, :home, node(), %{}, %{}))
+    push_redirect(socket, to: PageBuilder.live_dashboard_path(socket, :home, node(), %{}, %{}))
   end
 
   defp update_page(socket, assigns) do

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -279,7 +279,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   end
 
   def handle_event("show_info", %{"info" => info}, socket) do
-    to = live_dashboard_path(socket, socket.assigns.page, info: info)
+    to = PageBuilder.live_dashboard_path(socket, socket.assigns.page, info: info)
     {:noreply, push_patch(socket, to: to)}
   end
 

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -1,6 +1,7 @@
 defmodule Phoenix.LiveDashboard.EctoStatsPage do
   @moduledoc false
   use Phoenix.LiveDashboard.PageBuilder
+  import Phoenix.LiveDashboard.Helpers
 
   @compile {:no_warn_undefined, [Decimal, EctoPSQLExtras]}
   @disabled_link "https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html"

--- a/lib/phoenix/live_dashboard/pages/ets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ets_page.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.EtsPage do
   use Phoenix.LiveDashboard.PageBuilder
 
   alias Phoenix.LiveDashboard.SystemInfo
+  import Phoenix.LiveDashboard.Helpers
 
   @table_id :table
   @menu_text "ETS"

--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
   use Phoenix.LiveDashboard.PageBuilder
 
   import Phoenix.HTML
+  import Phoenix.LiveDashboard.Helpers
 
   alias Phoenix.LiveDashboard.SystemInfo
 

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   use Phoenix.LiveDashboard.PageBuilder
 
   import Phoenix.HTML
+  import Phoenix.LiveDashboard.Helpers
 
   alias Phoenix.LiveDashboard.SystemInfo
 

--- a/lib/phoenix/live_dashboard/pages/ports_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ports_page.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.PortsPage do
   use Phoenix.LiveDashboard.PageBuilder
 
   alias Phoenix.LiveDashboard.SystemInfo
+  import Phoenix.LiveDashboard.Helpers
 
   @table_id :table
   @menu_text "Ports"

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -1,6 +1,7 @@
 defmodule Phoenix.LiveDashboard.ProcessesPage do
   @moduledoc false
   use Phoenix.LiveDashboard.PageBuilder
+  import Phoenix.LiveDashboard.Helpers
 
   alias Phoenix.LiveDashboard.SystemInfo
 

--- a/lib/phoenix/live_dashboard/pages/sockets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/sockets_page.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.LiveDashboard.SocketsPage do
   use Phoenix.LiveDashboard.PageBuilder
 
   alias Phoenix.LiveDashboard.SystemInfo
+  import Phoenix.LiveDashboard.Helpers
 
   @table_id :table
   @menu_text "Sockets"

--- a/test/phoenix/live_dashboard/pages/applications_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/applications_page_test.exs
@@ -65,9 +65,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsPageTest do
   end
 
   defp applications_href(limit, search, sort_by, sort_dir) do
-    ~s|href="#{
-      Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))
-    }"|
+    ~s|href="#{Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))}"|
   end
 
   defp applications_path(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/pages/applications_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/applications_page_test.exs
@@ -65,7 +65,9 @@ defmodule Phoenix.LiveDashboard.ApplicationsPageTest do
   end
 
   defp applications_href(limit, search, sort_by, sort_dir) do
-    ~s|href="#{Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))}"|
+    ~s|href="#{
+      Plug.HTML.html_escape_to_iodata(applications_path(limit, search, sort_by, sort_dir))
+    }"|
   end
 
   defp applications_path(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/pages/ets_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/ets_page_test.exs
@@ -88,7 +88,7 @@ defmodule Phoenix.LiveDashboard.EtsPageTest do
 
   defp ets_info_path(ref, limit, sort_by, sort_dir) do
     ets_path(limit, "", sort_by, sort_dir) <>
-      "&info=#{Phoenix.LiveDashboard.Helpers.encode_ets(ref)}"
+      "&info=#{Phoenix.LiveDashboard.PageBuilder.encode_ets(ref)}"
   end
 
   defp ets_path(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/pages/ports_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/ports_page_test.exs
@@ -93,7 +93,7 @@ defmodule Phoenix.LiveDashboard.PortsPageTest do
 
   defp port_info_path(port, limit, sort_by, sort_dir) do
     ports_path(limit, "", sort_by, sort_dir) <>
-      "&info=#{Phoenix.LiveDashboard.Helpers.encode_port(port)}"
+      "&info=#{Phoenix.LiveDashboard.PageBuilder.encode_port(port)}"
   end
 
   defp ports_path(limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/pages/processes_live_test.exs
+++ b/test/phoenix/live_dashboard/pages/processes_live_test.exs
@@ -144,7 +144,7 @@ defmodule Phoenix.LiveDashboard.ProcessesLiveTest do
 
   defp process_info_path(prefix \\ "dashboard", pid, limit, sort_by, sort_dir) do
     processes_path(prefix, limit, "", sort_by, sort_dir) <>
-      "&info=#{Phoenix.LiveDashboard.Helpers.encode_pid(pid)}"
+      "&info=#{Phoenix.LiveDashboard.PageBuilder.encode_pid(pid)}"
   end
 
   defp processes_path(prefix \\ "dashboard", limit, search, sort_by, sort_dir) do

--- a/test/phoenix/live_dashboard/pages/sockets_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/sockets_page_test.exs
@@ -93,7 +93,7 @@ defmodule Phoenix.LiveDashboard.SocketsPageTest do
 
   defp socket_info_path(port, limit, sort_by, sort_dir) do
     sockets_path(limit, "", sort_by, sort_dir) <>
-      "&info=#{Phoenix.LiveDashboard.Helpers.encode_socket(port)}"
+      "&info=#{Phoenix.LiveDashboard.PageBuilder.encode_socket(port)}"
   end
 
   defp sockets_path(limit, search, sort_by, sort_dir) do


### PR DESCRIPTION
This makes the `encode_*`, `live_dashboard_path/2` and
`live_dashboard_path/3` functions available at `PageBuilder`.

The idea is to reduce the helper functions available when using
the page builder.

Closes #224.