### PR TITLE
Remember refresh selection using cookie

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,20 +8,29 @@ import PhxRequestLoggerCookie from "./request_logger_cookie"
 import PhxRequestLoggerQueryParameter from "./request_logger_query_parameter"
 import PhxRequestLoggerMessages from "./request_logger_messages"
 import PhxColorBarHighlight from "./color_bar_highlight"
+import PhxRememberRefresh from "./remember_refresh"
+import { loadRefreshData } from "./refresh";
 
 let Hooks = {
   PhxChartComponent: PhxChartComponent,
   PhxRequestLoggerCookie: PhxRequestLoggerCookie,
   PhxRequestLoggerQueryParameter: PhxRequestLoggerQueryParameter,
   PhxRequestLoggerMessages: PhxRequestLoggerMessages,
-  PhxColorBarHighlight: PhxColorBarHighlight
+  PhxColorBarHighlight: PhxColorBarHighlight,
+  PhxRememberRefresh: PhxRememberRefresh
 }
 
 let socketPath = document.querySelector("html").getAttribute("phx-socket") || "/live"
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket(socketPath, Socket, {
   hooks: Hooks,
-  params: { _csrf_token: csrfToken }
+  params: (liveViewName) => {
+    return {
+      _csrf_token: csrfToken,
+      // Pass the most recent refresh data to the LiveView in `connect_params`
+      refresh_data: loadRefreshData(),
+    };
+  },
 })
 
 

--- a/assets/js/refresh/index.js
+++ b/assets/js/refresh/index.js
@@ -3,10 +3,10 @@ const REFRESH_DATA_COOKIE = "_refresh_data";
 /**
  * Stores refresh data in the `"refresh_data"` cookie.
  */
-export function storeRefreshData(refreshData) {
+export function storeRefreshData(refreshData, path) {
   const json = JSON.stringify(refreshData);
   const encoded = encodeBase64(json);
-  setCookie(REFRESH_DATA_COOKIE, encoded, 157680000); // 5 years
+  setCookie(REFRESH_DATA_COOKIE, encoded, path, 157680000); // 5 years
 }
 
 /**
@@ -35,8 +35,8 @@ function getCookieValue(key) {
   }
 }
 
-function setCookie(key, value, maxAge) {
-  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
+function setCookie(key, value, path, maxAge) {
+  const cookie = `${key}=${value};max-age=${maxAge};path=${path}`;
   document.cookie = cookie;
 }
 

--- a/assets/js/refresh/index.js
+++ b/assets/js/refresh/index.js
@@ -1,0 +1,49 @@
+const REFRESH_DATA_COOKIE = "_refresh_data";
+
+/**
+ * Stores refresh data in the `"refresh_data"` cookie.
+ */
+export function storeRefreshData(refreshData) {
+  const json = JSON.stringify(refreshData);
+  const encoded = encodeBase64(json);
+  setCookie(REFRESH_DATA_COOKIE, encoded, 157680000); // 5 years
+}
+
+/**
+ * Loads refresh data from the `"refresh_data"` cookie.
+ */
+export function loadRefreshData() {
+  const encoded = getCookieValue(REFRESH_DATA_COOKIE);
+  if (encoded) {
+    const json = decodeBase64(encoded);
+    return JSON.parse(json);
+  } else {
+    return null;
+  }
+}
+
+function getCookieValue(key) {
+  const cookie = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith(`${key}=`));
+
+  if (cookie) {
+    const value = cookie.replace(`${key}=`, "");
+    return value;
+  } else {
+    return null;
+  }
+}
+
+function setCookie(key, value, maxAge) {
+  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
+  document.cookie = cookie;
+}
+
+function encodeBase64(string) {
+  return btoa(unescape(encodeURIComponent(string)));
+}
+
+function decodeBase64(binary) {
+  return decodeURIComponent(escape(atob(binary)));
+}

--- a/assets/js/remember_refresh/index.js
+++ b/assets/js/remember_refresh/index.js
@@ -6,7 +6,7 @@ const PhxRememberRefresh = {
   updated() {
     let config = loadRefreshData() || {};
     config[this.el.dataset.page] = this.el.value
-    storeRefreshData(config);
+    storeRefreshData(config, this.el.dataset.dashboardMountPath);
   }
 }
 

--- a/assets/js/remember_refresh/index.js
+++ b/assets/js/remember_refresh/index.js
@@ -1,0 +1,13 @@
+/** LiveView Hook **/
+
+import { storeRefreshData, loadRefreshData } from "../refresh";
+
+const PhxRememberRefresh = {
+  updated() {
+    let config = loadRefreshData() || {};
+    config[this.el.dataset.page] = this.el.value
+    storeRefreshData(config);
+  }
+}
+
+export default PhxRememberRefresh


### PR DESCRIPTION
This PR should close #233 

Once I finished the PR I realized that this cookie would be set for the whole page because of this: 

```
function setCookie(key, value, maxAge) {
  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
  document.cookie = cookie;
}
```

I cannot think a way to make this part "configurable" so the cookie would be sent only in the route where the dashboard is mounted :\ 

Maybe it is important for you maybe not, but at least something to consider :)

I didn't do any test because it involves some JS and I didn't see any test doing something similar. I just tested manually.