### PR TITLE
Update Simple Places to use ~H sigil

### DIFF
--- a/lib/phoenix/live_dashboard/components/nav_bar_component.ex
+++ b/lib/phoenix/live_dashboard/components/nav_bar_component.ex
@@ -106,7 +106,7 @@ defmodule Phoenix.LiveDashboard.NavBarComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <div>
       <div class="row">
         <div class="container">

--- a/lib/phoenix/live_dashboard/components/row_component.ex
+++ b/lib/phoenix/live_dashboard/components/row_component.ex
@@ -39,7 +39,7 @@ defmodule Phoenix.LiveDashboard.RowComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <div class="row">
       <%= for {component_module, component_params} <- @components do %>
         <%= live_component component_module, component_params %>

--- a/lib/phoenix/live_dashboard/components/usage_card_component.ex
+++ b/lib/phoenix/live_dashboard/components/usage_card_component.ex
@@ -57,7 +57,7 @@ defmodule Phoenix.LiveDashboard.UsageCardComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <%= if @title do %>
       <h5 class="card-title">
         <%= @title %>

--- a/lib/phoenix/live_dashboard/helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers.ex
@@ -140,7 +140,7 @@ defmodule Phoenix.LiveDashboard.Helpers do
   def hint(do: block) do
     assigns = %{block: block}
 
-    ~L"""
+    ~H"""
     <div class="hint">
       <svg class="hint-icon" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect width="44" height="44" fill="none"/>

--- a/lib/phoenix/live_dashboard/info/ets_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/ets_info_component.ex
@@ -22,7 +22,7 @@ defmodule Phoenix.LiveDashboard.EtsInfoComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <div class="tabular-info">
       <%= if @alive do %>
         <table class="table tabular-table-info-table">

--- a/lib/phoenix/live_dashboard/info/port_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/port_info_component.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <div class="tabular-info">
       <%= if @alive do %>
         <table class="table table-hover tabular-info-table">

--- a/lib/phoenix/live_dashboard/info/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/socket_info_component.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
 
   @impl true
   def render(assigns) do
-    ~L"""
+    ~H"""
     <div class="tabular-info">
       <%= if @alive do %>
         <table class="table table-hover tabular-info-table">

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   customizing the menu appearance. One notable difference, however,
   is that a page implements a `render_page/1` callback, which must
   return one or more page builder components, instead of a `render/1`
-  callback that returns `~L`.
+  callback that returns `~H` or `~L` (deprecated).
 
   A simple and straight-forward example of a custom page is the
   `Phoenix.LiveDashboard.ETSPage` that ships with the dashboard:

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -339,7 +339,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   defp maybe_link(_socket, _page, {:disabled, text}) do
     assigns = %{text: text}
 
-    ~L"""
+    ~H"""
     <div class="menu-item menu-item-disabled">
       <%= @text %>
     </div>
@@ -349,7 +349,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   defp maybe_link(_socket, _page, {:disabled, text, more_info_url}) do
     assigns = %{more_info_url: more_info_url, text: text}
 
-    ~L"""
+    ~H"""
     <div class="menu-item menu-item-disabled">
       <%= @text %> <%= link "Enable", to: @more_info_url, class: "menu-item-enable-button" %>
     </div>

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -69,7 +69,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
 
   def render_metrics(assigns) do
     fn ->
-      ~L"""
+      ~H"""
       <%= if @metrics do %>
         <div class="phx-dashboard-metrics-grid row">
         <%= for {metric, id} <- @metrics do %>

--- a/test/phoenix/live_dashboard/components/columns_component_test.exs
+++ b/test/phoenix/live_dashboard/components/columns_component_test.exs
@@ -9,7 +9,7 @@ defmodule Phoenix.LiveDashboard.ColumnsComponentTest do
     use Phoenix.LiveComponent
 
     def render(assigns) do
-      ~L"""
+      ~H"""
       <div><%= @text %></div>
       """
     end

--- a/test/phoenix/live_dashboard/components/nav_bar_component_test.exs
+++ b/test/phoenix/live_dashboard/components/nav_bar_component_test.exs
@@ -19,7 +19,7 @@ defmodule Phoenix.LiveDashboard.Components.NavBarComponentTest do
     use Phoenix.LiveComponent
 
     def render(assigns) do
-      ~L"""
+      ~H"""
       <div><%= @text %></div>
       """
     end

--- a/test/phoenix/live_dashboard/components/row_component_test.exs
+++ b/test/phoenix/live_dashboard/components/row_component_test.exs
@@ -9,7 +9,7 @@ defmodule Phoenix.LiveDashboard.RowComponentTest do
     use Phoenix.LiveComponent
 
     def render(assigns) do
-      ~L"""
+      ~H"""
       <div><%= @text %></div>
       """
     end


### PR DESCRIPTION
Replaces `~L` with `~H` in all the places where no further changes are required. (#299)