### PR TITLE
Allow to disable Metrics and Request logger pages

### DIFF
--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -42,7 +42,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
 
   @impl true
   def mount(_params, session, socket) do
-    {app_title, app_name} = session["home_app"]
+    {app_title, app_name} = session[:home_app]
 
     %{
       # Read once
@@ -52,7 +52,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
       system_limits: system_limits,
       # Updated periodically
       system_usage: system_usage
-    } = SystemInfo.fetch_system_info(socket.assigns.page.node, session["env_keys"], app_name)
+    } = SystemInfo.fetch_system_info(socket.assigns.page.node, session[:env_keys], app_name)
 
     socket =
       assign(socket,

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -48,6 +48,10 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
     :skip
   end
 
+  def menu_link(:disabled, _) do
+    :skip
+  end
+
   def menu_link(%{"metrics" => nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/metrics.html"}
   end

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -48,10 +48,6 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
     :skip
   end
 
-  def menu_link(:disabled, _) do
-    :skip
-  end
-
   def menu_link(%{"metrics" => nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/metrics.html"}
   end

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
   @menu_text "Metrics"
 
   @impl true
-  def mount(params, %{"metrics" => {mod, fun}, "metrics_history" => history}, socket) do
+  def mount(params, %{metrics: {mod, fun}, metrics_history: history}, socket) do
     all_metrics = apply(mod, fun, [])
     metrics_per_nav = Enum.group_by(all_metrics, &nav_name/1)
 
@@ -48,7 +48,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
     :skip
   end
 
-  def menu_link(%{"metrics" => nil}, _) do
+  def menu_link(%{metrics: nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/metrics.html"}
   end
 

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -43,6 +43,10 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
     :skip
   end
 
+  def menu_link(:disabled, _) do
+    :skip
+  end
+
   def menu_link(%{"request_logger" => nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/request_logger.html"}
   end

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -43,10 +43,6 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
     :skip
   end
 
-  def menu_link(:disabled, _) do
-    :skip
-  end
-
   def menu_link(%{"request_logger" => nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/request_logger.html"}
   end

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -7,8 +7,8 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
   @impl true
   def mount(%{"stream" => stream}, session, socket) do
     %{
-      "request_logger" => {param_key, cookie_key},
-      "cookie_domain" => cookie_domain
+      request_logger: {param_key, cookie_key},
+      cookie_domain: cookie_domain
     } = session
 
     if connected?(socket) do
@@ -32,7 +32,7 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
     {:ok, socket, temporary_assigns: [messages: []]}
   end
 
-  def mount(_, %{"request_logger" => _}, socket) do
+  def mount(_, %{request_logger: _}, socket) do
     stream = :crypto.strong_rand_bytes(3) |> Base.url_encode64()
     to = live_dashboard_path(socket, socket.assigns.page, stream: stream)
     {:ok, push_redirect(socket, to: to)}
@@ -43,7 +43,7 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
     :skip
   end
 
-  def menu_link(%{"request_logger" => nil}, _) do
+  def menu_link(%{request_logger: nil}, _) do
     {:disabled, @menu_text, "https://hexdocs.pm/phoenix_live_dashboard/request_logger.html"}
   end
 

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -307,7 +307,7 @@ defmodule Phoenix.LiveDashboard.Router do
 
     {pages, requirements} =
       [
-        home: {Phoenix.LiveDashboard.HomePage, %{"env_keys" => env_keys, "home_app" => home_app}},
+        home: {Phoenix.LiveDashboard.HomePage, %{env_keys: env_keys, home_app: home_app}},
         os_mon: {Phoenix.LiveDashboard.OSMonPage, %{}}
       ]
       |> Enum.concat(metrics_page(metrics, metrics_history))
@@ -343,8 +343,8 @@ defmodule Phoenix.LiveDashboard.Router do
 
   defp metrics_page(metrics, metrics_history) do
     session = %{
-      "metrics" => metrics,
-      "metrics_history" => metrics_history
+      metrics: metrics,
+      metrics_history: metrics_history
     }
 
     [metrics: {Phoenix.LiveDashboard.MetricsPage, session}]
@@ -354,8 +354,8 @@ defmodule Phoenix.LiveDashboard.Router do
 
   defp request_logger_page(conn, {true, cookie_domain}) do
     session = %{
-      "request_logger" => Phoenix.LiveDashboard.RequestLogger.param_key(conn),
-      "cookie_domain" => cookie_domain
+      request_logger: Phoenix.LiveDashboard.RequestLogger.param_key(conn),
+      cookie_domain: cookie_domain
     }
 
     [request_logger: {Phoenix.LiveDashboard.RequestLoggerPage, session}]

--- a/test/phoenix/live_dashboard/pages/metrics_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/metrics_page_test.exs
@@ -8,6 +8,9 @@ defmodule Phoenix.LiveDashboard.MetricsPageTest do
   test "menu_link/2" do
     assert :skip = Phoenix.LiveDashboard.MetricsPage.menu_link(%{}, %{dashboard_running?: false})
 
+    assert :skip =
+             Phoenix.LiveDashboard.MetricsPage.menu_link(:disabled, %{dashboard_running?: true})
+
     link = "https://hexdocs.pm/phoenix_live_dashboard/metrics.html"
 
     assert {:disabled, "Metrics", ^link} =

--- a/test/phoenix/live_dashboard/pages/metrics_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/metrics_page_test.exs
@@ -12,13 +12,13 @@ defmodule Phoenix.LiveDashboard.MetricsPageTest do
 
     assert {:disabled, "Metrics", ^link} =
              Phoenix.LiveDashboard.MetricsPage.menu_link(
-               %{"metrics" => nil},
+               %{metrics: nil},
                %{dashboard: true}
              )
 
     assert {:ok, "Metrics"} =
              Phoenix.LiveDashboard.MetricsPage.menu_link(
-               %{"metrics" => {Module, :fun}},
+               %{metrics: {Module, :fun}},
                %{dashboard: true}
              )
   end

--- a/test/phoenix/live_dashboard/pages/metrics_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/metrics_page_test.exs
@@ -8,9 +8,6 @@ defmodule Phoenix.LiveDashboard.MetricsPageTest do
   test "menu_link/2" do
     assert :skip = Phoenix.LiveDashboard.MetricsPage.menu_link(%{}, %{dashboard_running?: false})
 
-    assert :skip =
-             Phoenix.LiveDashboard.MetricsPage.menu_link(:disabled, %{dashboard_running?: true})
-
     link = "https://hexdocs.pm/phoenix_live_dashboard/metrics.html"
 
     assert {:disabled, "Metrics", ^link} =

--- a/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
@@ -12,6 +12,11 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPageTest do
     assert :skip =
              Phoenix.LiveDashboard.RequestLoggerPage.menu_link(%{}, %{dashboard_running?: false})
 
+    assert :skip =
+             Phoenix.LiveDashboard.RequestLoggerPage.menu_link(:disabled, %{
+               dashboard_running?: true
+             })
+
     link = "https://hexdocs.pm/phoenix_live_dashboard/request_logger.html"
 
     assert {:disabled, "Request Logger", ^link} =

--- a/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
@@ -16,13 +16,13 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPageTest do
 
     assert {:disabled, "Request Logger", ^link} =
              Phoenix.LiveDashboard.RequestLoggerPage.menu_link(
-               %{"request_logger" => nil},
+               %{request_logger: nil},
                %{dashboard: true}
              )
 
     assert {:ok, "Request Logger"} =
              Phoenix.LiveDashboard.RequestLoggerPage.menu_link(
-               %{"request_logger" => {"param", "cookie"}},
+               %{request_logger: {"param", "cookie"}},
                %{dashboard: true}
              )
   end

--- a/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/request_logger_page_test.exs
@@ -12,11 +12,6 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPageTest do
     assert :skip =
              Phoenix.LiveDashboard.RequestLoggerPage.menu_link(%{}, %{dashboard_running?: false})
 
-    assert :skip =
-             Phoenix.LiveDashboard.RequestLoggerPage.menu_link(:disabled, %{
-               dashboard_running?: true
-             })
-
     link = "https://hexdocs.pm/phoenix_live_dashboard/request_logger.html"
 
     assert {:disabled, "Request Logger", ^link} =

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -76,7 +76,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
 
     assert session_opts(metrics: false)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, :disabled, nil, [], {true, nil}, nil, [], nil]}
+              [nil, @home_app, false, :skip, nil, [], {true, nil}, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       session_opts(metrics: [])

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
     assert session_opts([]) == [
              session:
                {Phoenix.LiveDashboard.Router, :__session__,
-                [nil, @home_app, false, nil, nil, [], nil, nil, [], nil]},
+                [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]},
              root_layout: {Phoenix.LiveDashboard.LayoutView, :dash}
            ]
   end
@@ -68,11 +68,15 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures metrics" do
     assert session_opts(metrics: Foo)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, {Foo, :metrics}, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, {Foo, :metrics}, nil, [], {true, nil}, nil, [], nil]}
 
     assert session_opts(metrics: {Foo, :bar})[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, {Foo, :bar}, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, {Foo, :bar}, nil, [], {true, nil}, nil, [], nil]}
+
+    assert session_opts(metrics: false)[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, @home_app, false, :disabled, nil, [], {true, nil}, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       session_opts(metrics: [])
@@ -82,7 +86,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures env_keys" do
     assert session_opts(env_keys: ["USER", "ROOTDIR"])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [["USER", "ROOTDIR"], @home_app, false, nil, nil, [], nil, nil, [], nil]}
+              [["USER", "ROOTDIR"], @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       session_opts(env_keys: "FOO")
@@ -99,7 +103,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                 nil,
                 {MyStorage, :metrics_history, []},
                 [],
-                nil,
+                {true, nil},
                 nil,
                 [],
                 nil
@@ -117,15 +121,37 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures additional_pages" do
     assert session_opts(additional_pages: [])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
 
     assert session_opts(additional_pages: [custom: CustomPage])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [custom: {CustomPage, []}], nil, nil, [], nil]}
+              [
+                nil,
+                @home_app,
+                false,
+                nil,
+                nil,
+                [custom: {CustomPage, []}],
+                {true, nil},
+                nil,
+                [],
+                nil
+              ]}
 
     assert session_opts(additional_pages: [custom: {CustomPage, [1]}])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [custom: {CustomPage, [1]}], nil, nil, [], nil]}
+              [
+                nil,
+                @home_app,
+                false,
+                nil,
+                nil,
+                [custom: {CustomPage, [1]}],
+                {true, nil},
+                nil,
+                [],
+                nil
+              ]}
 
     assert_raise ArgumentError, fn ->
       session_opts(additional_pages: [{CustomPage, 1}])
@@ -143,15 +169,15 @@ defmodule Phoenix.LiveDashboard.RouterTest do
   test "configures cookie_domain" do
     assert session_opts(request_logger_cookie_domain: nil)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
 
     assert session_opts(request_logger_cookie_domain: ".acme.com")[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], ".acme.com", nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, ".acme.com"}, nil, [], nil]}
 
     assert session_opts(request_logger_cookie_domain: :parent)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], :parent, nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, :parent}, nil, [], nil]}
 
     assert_raise ArgumentError, fn ->
       session_opts(request_logger_cookie_domain: :unknown_atom)
@@ -162,20 +188,34 @@ defmodule Phoenix.LiveDashboard.RouterTest do
     end
   end
 
+  test "configures request logger" do
+    assert session_opts(request_logger: false)[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, @home_app, false, nil, nil, [], {false, nil}, nil, [], nil]}
+
+    assert session_opts(request_logger: true)[:session] ==
+             {Phoenix.LiveDashboard.Router, :__session__,
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
+
+    assert_raise ArgumentError, fn ->
+      session_opts(request_logger: :something_else)
+    end
+  end
+
   test "configures ecto_psql_extras" do
     assert session_opts(ecto_psql_extras_options: nil)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
 
     assert session_opts(ecto_psql_extras_options: [])[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], nil, nil, [], nil]}
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, [], nil]}
 
     ecto_args = [long_running_queries: [threshold: "200 milliseconds"]]
 
     assert session_opts(ecto_psql_extras_options: ecto_args)[:session] ==
              {Phoenix.LiveDashboard.Router, :__session__,
-              [nil, @home_app, false, nil, nil, [], nil, nil, ecto_args, nil]}
+              [nil, @home_app, false, nil, nil, [], {true, nil}, nil, ecto_args, nil]}
 
     assert_raise ArgumentError, fn ->
       session_opts(ecto_psql_extras_options: :not_a_list)
@@ -200,7 +240,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
         [],
         [],
         [],
-        nil,
+        {true, nil},
         nil,
         [],
         csp_session

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -251,15 +251,13 @@ defmodule Phoenix.LiveDashboard.RouterTest do
       assert %{
                "allow_destructive_actions" => false,
                "pages" => [
-                 home:
-                   {Phoenix.LiveDashboard.HomePage, %{"env_keys" => [], "home_app" => @home_app}},
+                 home: {Phoenix.LiveDashboard.HomePage, %{env_keys: [], home_app: @home_app}},
                  os_mon: {Phoenix.LiveDashboard.OSMonPage, %{}},
                  metrics:
-                   {Phoenix.LiveDashboard.MetricsPage,
-                    %{"metrics" => [], "metrics_history" => []}},
+                   {Phoenix.LiveDashboard.MetricsPage, %{metrics: [], metrics_history: []}},
                  request_logger:
                    {Phoenix.LiveDashboard.RequestLoggerPage,
-                    %{"request_logger" => nil, "cookie_domain" => nil}},
+                    %{request_logger: nil, cookie_domain: nil}},
                  applications: {Phoenix.LiveDashboard.ApplicationsPage, %{}},
                  processes: {Phoenix.LiveDashboard.ProcessesPage, %{}},
                  ports: {Phoenix.LiveDashboard.PortsPage, %{}},


### PR DESCRIPTION
This flag allows users to disable the Metrics and Request logger pages
completely.
It's useful in the context of [PLDS](https://github.com/phoenixframework/plds).