### PR TITLE
Show sockets created with {:inet_backend, :socket}

### DIFF
--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -704,10 +704,14 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
       <button phx-click="show-info" phx-value-info=<%= encode_socket(@socket) %>/>
   """
-  @spec encode_socket(port()) :: binary()
+  @spec encode_socket(port() | binary()) :: binary()
   def encode_socket(ref) when is_port(ref) do
     '#Port' ++ rest = :erlang.port_to_list(ref)
     "Socket#{rest}"
+  end
+
+  def encode_socket(ref) when is_binary(ref) do
+    ref
   end
 
   @doc """

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -501,9 +501,10 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   def sockets_callback(search, sort_by, sort_dir, limit) do
     sorter = if sort_dir == :asc, do: &<=/2, else: &>=/2
+    sockets = Port.list() ++ :gen_tcp_socket.which_sockets() ++ :gen_udp_socket.which_sockets()
 
     sockets =
-      for port <- Port.list(), info = socket_info(port), show_socket?(info, search), do: info
+      for port <- sockets, info = socket_info(port), show_socket?(info, search), do: info
 
     count = length(sockets)
     sockets = sockets |> Enum.sort_by(&Keyword.fetch!(&1, sort_by), sorter) |> Enum.take(limit)
@@ -515,6 +516,25 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       nil -> :error
       info -> {:ok, info}
     end
+  end
+
+  defp socket_info({:"$inet", gen_socket_mod, {pid, {:"$socket", _ref}}} = socket) do
+     with info when not is_nil(info) <- gen_socket_mod.info(socket),
+          port <- get_socket_fd(socket, gen_socket_mod) do
+      [
+        module: gen_socket_mod,
+        port: port,
+        local_address: format_address(gen_socket_mod.sockname(socket)),
+        foreign_address: format_address(gen_socket_mod.peername(socket)),
+        state: format_socket_state(info[:rstates]),
+        type: info[:type],
+        connected: pid,
+        send_oct: info[:counters][:send_oct],
+        recv_oct: info[:counters][:recv_oct]
+      ]
+     else
+      _ -> nil
+     end
   end
 
   defp socket_info(port) do
@@ -535,6 +555,13 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       ] ++ stat
     else
       _ -> nil
+    end
+  end
+
+  defp get_socket_fd(socket, gen_socket_mod) do
+    case gen_socket_mod.getopts(socket, [:fd]) do
+      {:ok, [fd: fd]} -> "esock[#{fd}]"
+      _ -> "esock"
     end
   end
 
@@ -615,6 +642,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       [:bound, :listen | _] -> "LISTEN"
       [:bound, :connecting | _] -> "CONNECTING"
       [:bound, :open] -> "BOUND"
+      [:bound, :selected] -> "CONNECTED"
       [:connected, :open] -> "CONNECTED"
       [:open] -> "IDLE"
       [] -> "CLOSED"

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -519,7 +519,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   defp gen_tcp_sockets() do
     if function_exported?(:gen_tcp_socket, :which_sockets, 0) do
-      :gen_tcp_socket.which_sockets()
+      apply(:gen_tcp_socket, :which_sockets, [])
     else
       []
     end
@@ -527,7 +527,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   defp gen_udp_sockets() do
     if function_exported?(:gen_udp_socket, :which_sockets, 0) do
-      :gen_udp_socket.which_sockets()
+      apply(:gen_udp_socket, :which_sockets, [])
     else
       []
     end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -122,15 +122,24 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       assert count > 1
     end
 
-    test "includes :gen_tcp_socket and :gen_udp_socket" do
-      if Code.ensure_loaded?(:gen_udp_socket) do
+    test "includes :gen_tcp_socket" do
+      if Code.ensure_loaded?(:gen_tcp_socket) do
         :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
-        :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 
         {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
         socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
 
         assert :gen_tcp_socket in socket_mods
+      end
+    end
+
+    test "includes :gen_udp_socket" do
+      if Code.ensure_loaded?(:gen_udp_socket) do
+        :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+
+        {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
+        socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
+
         assert :gen_udp_socket in socket_mods
       end
     end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -123,14 +123,22 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     end
 
     test "includes :gen_tcp_socket and :gen_udp_socket" do
-      :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
-      :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+      socket_backend_supported? =
+        try do
+          :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+          :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+          true
+        rescue
+          _ -> false
+        end
 
-      {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
-      socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
+      if socket_backend_supported? do
+        {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
+        socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
 
-      assert :gen_tcp_socket in socket_mods
-      assert :gen_udp_socket in socket_mods
+        assert :gen_tcp_socket in socket_mods
+        assert :gen_udp_socket in socket_mods
+      end
     end
 
     test "all with search" do

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -123,16 +123,10 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     end
 
     test "includes :gen_tcp_socket and :gen_udp_socket" do
-      socket_backend_supported? =
-        try do
-          :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
-          :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
-          true
-        rescue
-          _ -> false
-        end
+      if Code.ensure_loaded?(:gen_udp_socket) do
+        :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+        :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 
-      if socket_backend_supported? do
         {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
         socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
 

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -122,6 +122,17 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       assert count > 1
     end
 
+    test "includes :gen_tcp_socket and :gen_udp_socket" do
+      :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+      :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
+
+      {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)
+      socket_mods = Enum.map(sockets, fn socket -> socket[:module] end)
+
+      assert :gen_tcp_socket in socket_mods
+      assert :gen_udp_socket in socket_mods
+    end
+
     test "all with search" do
       open_socket()
 

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -122,8 +122,8 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       assert count > 1
     end
 
-    test "includes :gen_tcp_socket" do
-      if Code.ensure_loaded?(:gen_tcp_socket) do
+    if Code.ensure_loaded?(:gen_tcp_socket) do
+      test "includes :gen_tcp_socket" do
         :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 
         {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -133,8 +133,8 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       end
     end
 
-    test "includes :gen_udp_socket" do
-      if Code.ensure_loaded?(:gen_udp_socket) do
+    if Code.ensure_loaded?(:gen_udp_socket) do
+      test "includes :gen_udp_socket" do
         :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 
         {sockets, _count} = SystemInfo.fetch_sockets(node(), "", :send_oct, :asc, 100)

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -122,7 +122,8 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       assert count > 1
     end
 
-    if Code.ensure_loaded?(:gen_tcp_socket) do
+    if Code.ensure_loaded?(:gen_tcp_socket) &&
+         function_exported?(:gen_tcp_socket, :which_sockets, 0) do
       test "includes :gen_tcp_socket" do
         :gen_tcp.listen(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 
@@ -133,7 +134,8 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       end
     end
 
-    if Code.ensure_loaded?(:gen_udp_socket) do
+    if Code.ensure_loaded?(:gen_udp_socket) &&
+         function_exported?(:gen_udp_socket, :which_sockets, 0) do
       test "includes :gen_udp_socket" do
         :gen_udp.open(0, inet_backend: :socket, ip: {127, 0, 0, 1})
 


### PR DESCRIPTION
I'm working on a project that uses the new NIF backend for sockets, and I noticed that they do not appear on the sockets page of the live dashboard.

I see that live dashboard declares support for Elixir 1.7, which supports OTP 19-22. I'm not sure exactly when new socket interface was added, but I'm certain not as early as OTP 19. The feature I'm relying on, `:gen_udp` with `{:inet_backend, :socket}` was only added in OTP 24.1.

I wanted to suggest this as a draft implementation, pending discussion about compatibility. Do you have suggestions for how to safely add this feature, while not breaking the library for people who might be using older Elixir/OTP versions?