### PR TITLE
Add more info for PIDs to ease navigation

### DIFF
--- a/lib/phoenix/live_dashboard/helpers.ex
+++ b/lib/phoenix/live_dashboard/helpers.ex
@@ -1,19 +1,39 @@
 defmodule Phoenix.LiveDashboard.Helpers do
   @moduledoc false
 
-  alias Phoenix.LiveDashboard.PageBuilder
+  alias Phoenix.LiveDashboard.{PageBuilder, SystemInfo}
   import Phoenix.LiveView.Helpers
   @format_limit 100
 
   @doc """
   Formats any value.
   """
+  def format_value(
+        %SystemInfo.ProcessDetails{pid: pid, name_or_initial_call: name_or_initial_call},
+        live_dashboard_path
+      ) do
+    live_patch("#{inspect(pid)} - #{name_or_initial_call}",
+      to: live_dashboard_path.(node(pid), info: PageBuilder.encode_pid(pid))
+    )
+  end
+
+  def format_value(
+        %SystemInfo.PortDetails{port: port, description: description},
+        live_dashboard_path
+      ) do
+    live_patch("#{inspect(port)} - #{description}",
+      to: live_dashboard_path.(node(port), info: PageBuilder.encode_port(port))
+    )
+  end
+
+  # Not used in `phoenix_live_dashboard` code, but available for custom pages
   def format_value(port, live_dashboard_path) when is_port(port) do
     live_patch(inspect(port),
       to: live_dashboard_path.(node(port), info: PageBuilder.encode_port(port))
     )
   end
 
+  # Not used in `phoenix_live_dashboard` code, but available for custom pages
   def format_value(pid, live_dashboard_path) when is_pid(pid) do
     live_patch(inspect(pid),
       to: live_dashboard_path.(node(pid), info: PageBuilder.encode_pid(pid))

--- a/lib/phoenix/live_dashboard/info/process_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/process_info_component.ex
@@ -42,7 +42,8 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
             <tr><td>Initial call</td><td><pre><%= @initial_call %></pre></td></tr>
             <tr><td>Status</td><td><pre><%= @status %></pre></td></tr>
             <tr><td>Message queue length</td><td><pre><%= @message_queue_len %></pre></td></tr>
-            <tr><td>Links</td><td><pre><%= @links %></pre></td></tr>
+            <tr><td>Ancestors</td><td><pre><%= @ancestor_links %></pre></td></tr>
+            <tr><td>Other links</td><td><pre><%= @other_links %></pre></td></tr>
             <tr><td>Monitors</td><td><pre><%= @monitors %></pre></td></tr>
             <tr><td>Monitored by</td><td><pre><%= @monitored_by %></pre></td></tr>
             <tr><td>Trap exit</td><td><pre><%= @trap_exit %></pre></td></tr>
@@ -89,8 +90,17 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
   defp assign_info(%{assigns: assigns} = socket) do
     case SystemInfo.fetch_process_info(assigns.pid) do
       {:ok, info} ->
-        Enum.reduce(info, socket, fn {key, val}, acc ->
-          assign(acc, key, format_info(key, val, assigns.path))
+        Enum.reduce(info, socket, fn
+          {:ancestors, ancestors}, acc ->
+            acc
+            |> assign(:ancestor_links, format_info(:links, ancestors, assigns.path))
+            |> assign(
+              :other_links,
+              format_info(:links, info[:links] -- ancestors, assigns.path)
+            )
+
+          {key, val}, acc ->
+            assign(acc, key, format_info(key, val, assigns.path))
         end)
         |> assign(alive: true)
 

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -53,16 +53,16 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     end
 
     test "info" do
-      {:ok, pid} = SystemInfo.fetch_process_info(Process.whereis(:user))
-      assert pid[:registered_name] == :user
-      assert is_integer(pid[:message_queue_len])
-      assert pid[:initial_call] == {:erlang, :apply, 2}
+      {:ok, info} = SystemInfo.fetch_process_info(Process.whereis(:user))
+      assert info[:registered_name] == :user
+      assert is_integer(info[:message_queue_len])
+      assert info[:initial_call] == {:erlang, :apply, 2}
 
-      {:ok, pid} =
-        SystemInfo.fetch_process_info(Process.whereis(Phoenix.LiveDashboard.DynamicSupervisor))
+      pid = Process.whereis(Phoenix.LiveDashboard.DynamicSupervisor)
+      {:ok, info} = SystemInfo.fetch_process_info(pid)
 
-      assert pid[:registered_name] == Phoenix.LiveDashboard.DynamicSupervisor
-      assert pid[:initial_call] == {:supervisor, Supervisor.Default, 1}
+      assert info[:registered_name] == Phoenix.LiveDashboard.DynamicSupervisor
+      assert info[:initial_call] == {:supervisor, Supervisor.Default, 1}
     end
   end
 
@@ -85,7 +85,12 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     test "info" do
       {:ok, port} = SystemInfo.fetch_port_info(hd(Port.list()))
       assert port[:name] == 'forker'
-      assert inspect(port[:connected]) == "#PID<0.0.0>"
+
+      connected_details = port[:connected]
+      %module{pid: pid} = connected_details
+
+      assert module == SystemInfo.ProcessDetails
+      assert pid == :erlang.list_to_pid('<0.0.0>')
     end
   end
 


### PR DESCRIPTION
 * Show 'registered_name' (if it exists) or the  to describe processes
 * Split links for process modal into 'older' and 'newer' processes, which would often correspond to supervisors and children / clients

There might be a better way to split process than "older" and "newer".  I'd love feedback on that.

<img width="904" alt="Screenshot 2021-10-14 at 20 31 38" src="https://user-images.githubusercontent.com/301415/137375832-7c0f4fb7-77f6-4a38-8d9e-780de11ca420.png">