### PR TITLE
When pruning metric charts, just slice the last pruneThreshold values.

### DIFF
--- a/assets/js/metrics_live/index.js
+++ b/assets/js/metrics_live/index.js
@@ -175,6 +175,8 @@ class CommonMetric {
 
   handleMeasurements(measurements) {
     // prune datasets when we reach the max number of events
+    measurements.forEach((measurement) => this.__handler.call(this, measurement, this.__callback))
+
     let currentSize = this.datasets[0].data.length
     if (currentSize >= this.pruneThreshold) {
       this.datasets = this.datasets.map(({ data, ...rest }) => {
@@ -182,7 +184,6 @@ class CommonMetric {
       })
     }
 
-    measurements.forEach((measurement) => this.__handler.call(this, measurement, this.__callback))
     this.chart.setData(dataForDatasets(this.datasets))
   }
 }
@@ -210,8 +211,8 @@ class Summary {
   }
 
   handleMeasurements(measurements) {
-    this.__maybePruneDatasets()
     measurements.forEach((measurement) => this.__handler(measurement))
+    this.__maybePruneDatasets()
     this.chart.setData(dataForDatasets(this.datasets))
   }
 
@@ -284,7 +285,7 @@ class Summary {
 
   __maybePruneDatasets() {
     let currentSize = this.datasets[0].data.length
-    if (currentSize >= this.pruneThreshold) {
+    if (currentSize > this.pruneThreshold) {
       let start = -this.pruneThreshold;
       this.datasets = this.datasets.map(({ key, data, agg }) => {
         let dataPruned = data.slice(start)

--- a/assets/test/metrics_live_test.js
+++ b/assets/test/metrics_live_test.js
@@ -246,8 +246,8 @@ describe('Metrics no tags', () => {
     ])
 
     expect(mockSetData).toHaveBeenCalledWith([
-      [3, 4, 5],
-      [5, 7, 9]
+      [2, 3, 4, 5],
+      [3, 5, 7, 9]
     ])
   })
 })
@@ -461,7 +461,7 @@ describe('Metrics with tags', () => {
       ])
     })
 
-    test('when dataset > pruneThreshold, prunes data and aggregations by half', () => {
+    test('when dataset > pruneThreshold, prunes data to length of pruneThreshold', () => {
       const chart = new TelemetryChart(document.body, { metric: 'summary', tagged: true, pruneThreshold: 6 })
 
       // Fill the chart
@@ -523,9 +523,9 @@ describe('Metrics with tags', () => {
       ])
 
       expect(mockSetData).toHaveBeenCalledWith([
-        [4, 5, 6, 7],
-        [null, 2, null, 6],
-        [0, null, 4, null]
+        [2, 3, 4, 5, 6, 7],
+        [null, -2, null, 2, null, 6],
+        [-4, null, 0, null, 4, null]
       ])
     })
   })


### PR DESCRIPTION
The effect is smoother and easier to follow data points as data scrolls in

There may be a reason it does this, though, that I don't know.