### PR TITLE
Add optional ordering for ecto_stats queries

### DIFF
--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -164,7 +164,12 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   @forbidden_tables [:kill_all, :mandelbrot]
 
   defp items(%{repo: repo, info_module: info_module, ecto_options: ecto_options, node: node}) do
-    for {table_name, table_module} <- info_module.queries({repo, node}),
+    sorted_queries =
+      Enum.sort(info_module.queries({repo, node}), fn a, b ->
+        elem(a, 1).info[:index] < elem(b, 1).info[:index]
+      end)
+
+    for {table_name, table_module} <- sorted_queries,
         table_name not in @forbidden_tables do
       {table_name,
        name: Phoenix.Naming.humanize(table_name),


### PR DESCRIPTION
This PR adds an optional ordering to `ecto_psql_extras` queries. The main reason for this change is to highlight the recently added `diagnose` method (https://github.com/pawurb/ecto_psql_extras#diagnose-report) as selected by default. 

The new `index` property is optional so it won't break integration with `ecto_mysql_extras`. 

<img width="1161" alt="Screen Shot 2021-11-13 at 00 37 22" src="https://user-images.githubusercontent.com/1131944/141596079-46895e5d-9ce2-43ab-ae37-43ea324b3f1a.png">
