### PR TITLE
Add module for handle_metrics

### DIFF
--- a/lib/phoenix/live_dashboard/telemetry_listener.ex
+++ b/lib/phoenix/live_dashboard/telemetry_listener.ex
@@ -76,7 +76,7 @@ defmodule Phoenix.LiveDashboard.TelemetryListener do
 
     for {event_name, metrics} <- metrics_per_event do
       id = {__MODULE__, event_name, self()}
-      :telemetry.attach(id, event_name, &handle_metrics/4, {parent, metrics})
+      :telemetry.attach(id, event_name, &__MODULE__.handle_metrics/4, {parent, metrics})
     end
 
     {:ok, %{ref: ref, events: Map.keys(metrics_per_event)}}


### PR DESCRIPTION
Using `telemetry 1.0.0` and `phoenix_live_dashboard 0.6.1`, there are some noisy warnings about a performance penalty:

```
https://hexdocs.pm/telemetry/telemetry.html#attach-4
[info] Function passed as a handler with ID {Phoenix.LiveDashboard.TelemetryListener, [:app, :event], #PID<0.585.0>} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.
```

Not sure which version this warning was added to, but adding `__MODULE__` removes it.

Telemetry warning:
https://github.com/beam-telemetry/telemetry/blob/9a9da7b837b3fb896745702d7b341637a96c09ad/src/telemetry.erl#L396-L402
