### PR TITLE
Add rolling statistics to summary graph

### DIFF
--- a/assets/js/metrics_live/index.js
+++ b/assets/js/metrics_live/index.js
@@ -115,6 +115,18 @@ function nextTaggedValueForCallback({ x, y, z }, callback) {
 }
 
 const getPruneThreshold = ({ pruneThreshold = 1000 }) => pruneThreshold
+const getDeriveSeries = ({ deriveModes = "" }) => {
+  let deriveSeries = {}
+  if (deriveModes !== ""){
+    deriveModes.split("~").forEach(
+      mode => (
+        deriveSeries["-" + mode] = mode
+      )
+    )
+  }
+  return deriveSeries
+}
+const getDeriveWindowSecs = ({ deriveWindowSecs = 120 }) => deriveWindowSecs
 
 // Handles the basic metrics like Counter, LastValue, and Sum.
 class CommonMetric {
@@ -196,16 +208,24 @@ class Summary {
     // Bind the series `values` callback to this instance
     config.series[1].values = this.__seriesValues.bind(this)
 
-    this.datasets = [{ key: "|x|", data: [] }]
+    this.datasets = [{ key: "|x|", data: [], derived: {from: -1, mode: "", dataRaw: []}}]
     this.chart = new uPlot(config, this.constructor.initialData(options), chartEl)
     this.pruneThreshold = getPruneThreshold(options)
     this.options = options
+    this.options.deriveSeries = getDeriveSeries(options)
+    this.options.deriveWindowSecs = getDeriveWindowSecs(options)
 
     if (options.tagged) {
       this.chart.delSeries(1)
       this.__handler = this.handleTaggedMeasurement.bind(this)
     } else {
-      this.datasets.push(this.constructor.newDataset(options.label))
+      this.datasets.push(this.constructor.newDataset(options.label, -1, "", 0))
+      Object.entries(this.options.deriveSeries).forEach(
+        entry => {
+          let [suffix, deriveMode] = entry
+          this.findOrCreateSeries(options.label + suffix, 1, deriveMode)
+        }
+      )
       this.__handler = this.handleMeasurement.bind(this)
     }
   }
@@ -217,8 +237,20 @@ class Summary {
   }
 
   handleTaggedMeasurement(measurement) {
-    let seriesIndex = this.findOrCreateSeries(measurement.x)
-    this.handleMeasurement(measurement, seriesIndex)
+    let rootSeriesIndex = this.findOrCreateSeries(measurement.x, -1, "")
+
+    //handle derived series creation
+    Object.entries(this.options.deriveSeries).forEach(
+        entry => {
+            let [suffix, deriveMode] = entry 
+            let label = measurement.x + suffix
+            //we create the series here. the update will be handeled below
+            this.findOrCreateSeries(label, rootSeriesIndex, deriveMode)
+        }
+    )
+
+    //actually do the measurements
+    this.handleMeasurement(measurement, rootSeriesIndex)
   }
 
   handleMeasurement(measurement, sidx = 1) {
@@ -226,20 +258,20 @@ class Summary {
     this.datasets = this.datasets.map((dataset, index) => {
       if (dataset.key === "|x|") {
         dataset.data.push(timestamp)
-      } else if (index === sidx) {
+      } else if (index === sidx || dataset.derived.from === sidx) {
         this.pushToDataset(dataset, measurement)
       } else {
-        this.pushToDataset(dataset, null)
+         this.pushToDataset(dataset, null)
       }
       return dataset
     })
   }
 
-  findOrCreateSeries(label) {
+  findOrCreateSeries(label, derivedFrom, deriveMode) {
     let seriesIndex = this.datasets.findIndex(({ key }) => label === key)
     if (seriesIndex === -1) {
       seriesIndex = this.datasets.push(
-        this.constructor.newDataset(label, this.datasets[0].data.length)
+        this.constructor.newDataset(label, derivedFrom, deriveMode, this.datasets[0].data.length)
       ) - 1
 
       let config = {
@@ -259,18 +291,57 @@ class Summary {
       dataset.agg.avg.push(null)
       dataset.agg.max.push(null)
       dataset.agg.min.push(null)
+
+      if (dataset.derived.from !== -1){
+        dataset.derived.dataRaw.push(null)
+      }
+
       return
     }
 
-    let { y } = measurement
+    var { y, z: timestamp } = measurement
 
     // Increment the new overall totals
     dataset.agg.count++
-    dataset.agg.total += y
 
-    // Push the value
+    if (dataset.derived.from !== -1) {
+        // Push the raw value
+        dataset.derived.dataRaw.push(measurement)
+        let mode = dataset.derived.mode
+        if (mode !== undefined && mode !== ""){
+            // perform windowing
+            let windowedData = dataset.derived.dataRaw.filter(v => {
+                if (v !== null){
+                    return v.z >= (timestamp - this.options.deriveWindowSecs)
+                }
+                return false
+                }
+            ).map(
+                v => {
+                    return v.y
+                }
+            )
+            let isPercentile = mode[0] == "p"
+            if (isPercentile) {
+                let percTarget = parseInt(mode.slice(1))
+                let sortedData = Array.from(windowedData).sort()
+                let dataLength = sortedData.length
+                let idx = Math.floor((percTarget / 100) * (dataLength - 1))
+                y = sortedData[idx]
+            } else if (mode == "mean"){
+                //mean
+                const reducer = (x,y) => x+y
+                y = windowedData.reduce(reducer) / windowedData.length
+            } else {
+                console.error("Unknown deriveMode")
+            }
+        }
+    }
+
+    //Push the usable value (potentially derived)
     dataset.data.push(y)
 
+    dataset.agg.total += y
     // Push min/max/avg
     if (dataset.last.min === null || y < dataset.last.min) { dataset.last.min = y }
     dataset.agg.min.push(dataset.last.min)
@@ -285,12 +356,22 @@ class Summary {
 
   __maybePruneDatasets() {
     let currentSize = this.datasets[0].data.length
+
     if (currentSize > this.pruneThreshold) {
       let start = -this.pruneThreshold;
-      this.datasets = this.datasets.map(({ key, data, agg }) => {
+      this.datasets = this.datasets.map(({ key, data, derived, agg }) => {
         let dataPruned = data.slice(start)
+        let derivedDataRawPruned = derived.dataRaw.slice(start)
+
+
+        let derivedPruned = {
+            from: derived.from,
+            mode: derived.mode,
+            dataRaw: derivedDataRawPruned
+        }
+
         if (!agg) {
-          return { key, data: dataPruned }
+          return { key, data: dataPruned, derived: derivedPruned}
         }
 
         let { avg, count, max, min, total } = agg
@@ -298,8 +379,9 @@ class Summary {
         let maxPruned = max.slice(start)
 
         return {
-          key,
+          key, 
           data: dataPruned,
+          derived: derivedPruned,
           agg: {
             avg: avg.slice(start),
             count,
@@ -360,10 +442,15 @@ class Summary {
     }
   }
 
-  static newDataset(key, length = 0) {
+  static newDataset(key, derivedFrom, deriveMode, length = 0) {
     let nils = length > 0 ? Array(length).fill(null) : []
     return {
       key,
+      derived: {
+        from: derivedFrom,
+        mode: deriveMode,
+        dataRaw: (derivedFrom !== -1) ? [...nils] : [],
+      },
       data: [...nils],
       agg: { avg: [...nils], count: 0, max: [...nils], min: [...nils], total: 0 },
       last: { max: null, min: null }

--- a/assets/test/metrics_live_test.js
+++ b/assets/test/metrics_live_test.js
@@ -137,10 +137,15 @@ describe('Metrics no tags', () => {
     const chart = new TelemetryChart(document.body, { metric: 'summary', tagged: false, label: "Duration" })
 
     expect(chart.metric.datasets).toEqual([
-      { key: "|x|", data: [] },
+      { key: "|x|", data: [], derived: {from: -1, mode: "", dataRaw: []}},
       {
         key: "Duration",
         data: [],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        },
         agg: {
           avg: [],
           min: [],
@@ -165,11 +170,21 @@ describe('Metrics no tags', () => {
     expect(chart.metric.datasets).toEqual([
       {
         key: "|x|",
-        data: [1]
+        data: [1],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        }
       },
       {
         key: "Duration",
         data: [2],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        },
         agg: {
           avg: [2],
           min: [2],
@@ -204,11 +219,21 @@ describe('Metrics no tags', () => {
     expect(chart.metric.datasets).toEqual([
       {
         key: "|x|",
-        data: [1, 3, 5, 7]
+        data: [1, 3, 5, 7],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        }
       },
       {
         key: "Duration",
         data: [2, 4, 6, 8],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        },
         agg: {
           avg: [2, 3, 4, 5],
           min: [2, 2, 2, 2],
@@ -218,6 +243,115 @@ describe('Metrics no tags', () => {
         },
         last: {
           max: 8,
+          min: 2
+        }
+      }
+    ])
+  })
+
+  test('Summary (derived)', () => {
+    const chart = new TelemetryChart(document.body, { metric: 'summary', tagged: false, label: "Duration", deriveModes:"mean"
+   })
+
+    expect(chart.metric.datasets).toEqual([
+      { key: "|x|", data: [], derived: {from: -1, mode: "", dataRaw: []}},
+      {
+        key: "Duration",
+        data: [],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        },
+        agg: {
+          avg: [],
+          min: [],
+          max: [],
+          count: 0,
+          total: 0
+        },
+        last: {
+          max: null,
+          min: null
+        }
+      },
+      {
+        key: "Duration-mean",
+        data: [],
+        derived: {
+          from: 1,
+          mode: "mean",
+          dataRaw: []
+        },
+        agg: {
+          avg: [],
+          min: [],
+          max: [],
+          count: 0,
+          total: 0
+        },
+        last: {
+          max: null,
+          min: null
+        }
+      }
+    ])
+
+    chart.pushData([{ x: 'a', y: 2, z: 1 }])
+
+    expect(mockSetData).toHaveBeenCalledWith([
+      [1],
+      [2],
+      [2]
+    ])
+
+    expect(chart.metric.datasets).toEqual([
+      {
+        key: "|x|",
+        data: [1],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        }
+      },
+      {
+        key: "Duration",
+        data: [2],
+        derived: {
+          from: -1,
+          mode: "",
+          dataRaw: []
+        },
+        agg: {
+          avg: [2],
+          min: [2],
+          max: [2],
+          count: 1,
+          total: 2
+        },
+        last: {
+          max: 2,
+          min: 2
+        }
+      },
+      {
+        key: "Duration-mean",
+        data: [2],
+        derived: {
+          from: 1,
+          mode: "mean",
+          dataRaw: [{ x: 'a', y: 2, z: 1}]
+        },
+        agg: {
+          avg: [2],
+          min: [2],
+          max: [2],
+          count: 1,
+          total: 2
+        },
+        last: {
+          max: 2,
           min: 2
         }
       }
@@ -384,11 +518,21 @@ describe('Metrics with tags', () => {
       expect(chart.metric.datasets).toEqual([
         {
           key: "|x|",
-          data: [1]
+          data: [1],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          }
         },
         {
           key: "a",
           data: [2],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          },
           agg: {
             avg: [2],
             min: [2],
@@ -414,11 +558,21 @@ describe('Metrics with tags', () => {
       expect(chart.metric.datasets).toEqual([
         {
           key: "|x|",
-          data: [1, 3]
+          data: [1, 3],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          }
         },
         {
           key: "a",
           data: [2, null],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          },
           agg: {
             avg: [2, null],
             min: [2, null],
@@ -434,6 +588,11 @@ describe('Metrics with tags', () => {
         {
           key: "b",
           data: [null, 4],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          },
           agg: {
             avg: [null, 4],
             min: [null, 4],
@@ -483,11 +642,21 @@ describe('Metrics with tags', () => {
       expect(chart.metric.datasets).toEqual([
         {
           key: "|x|",
-          data: [1, 2, 3, 4, 5, 6]
+          data: [1, 2, 3, 4, 5, 6],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          }
         },
         {
           key: "a",
           data: [-6, null, -2, null, 2, null],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          },
           agg: {
             avg: [-6, null, -4, null, -2, null],
             min: [-6, null, -6, null, -6, null],
@@ -503,6 +672,11 @@ describe('Metrics with tags', () => {
         {
           key: "b",
           data: [null, -4, null, 0, null, 4],
+          derived: {
+            from: -1,
+            mode: "",
+            dataRaw: []
+          },
           agg: {
             avg: [null, -4, null, -2, null, 0],
             min: [null, -4, null, -4, null, -4],
@@ -528,7 +702,400 @@ describe('Metrics with tags', () => {
         [-4, null, 0, null, 4, null]
       ])
     })
+
+    describe("Derived series", () => {
+      test("adds series", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean~p90"
+       })
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        chart.pushData([{ x: "a", y: 2, z: 1 }])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1],
+          [2],
+          [2],
+          [2],
+        ])
+
+        expect(chart.metric.datasets).toEqual([
+        {
+            key: "|x|",
+            data: [1],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            }
+          },
+          {
+            key: "a",
+            data: [2],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            },
+            agg: {
+              avg: [2],
+              min: [2],
+              max: [2],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          },
+          {
+            key: "a-mean",
+            data: [2],
+            derived: {
+              from: 1,
+              mode: "mean",
+              dataRaw: [{ x: "a", y: 2, z: 1 }]
+            },
+            agg: {
+              avg: [2],
+              min: [2],
+              max: [2],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          },
+          {
+            key: "a-p90",
+            data: [2],
+            derived: {
+              from: 1,
+              mode: "p90",
+              dataRaw: [{ x: "a", y: 2, z: 1 }]
+            },
+            agg: {
+              avg: [2],
+              min: [2],
+              max: [2],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          }
+        ])
+      })
+
+      test("aligns derived series by tag", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean"
+        })
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        chart.pushData([{ x: "a", y: 2, z: 1 }])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1],
+          [2],
+          [2],
+        ])
+
+        expect(chart.metric.datasets).toEqual([
+          {
+            key: "|x|",
+            data: [1],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            }
+          },
+          {
+            key: "a",
+            data: [2],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            },
+            agg: {
+              avg: [2],
+              min: [2],
+              max: [2],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          },
+          {
+            key: "a-mean",
+            data: [2],
+            derived: {
+              from: 1,
+              mode: "mean",
+              dataRaw: [{ x: "a", y: 2, z: 1 }]
+            },
+            agg: {
+              avg: [2],
+              min: [2],
+              max: [2],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          }
+        ])
+
+        chart.pushData([{ x: "b", y: 4, z: 3 }])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1, 3],
+          [2, null],
+          [2, null],
+          [null, 4],
+          [null, 4]
+        ])
+
+        expect(chart.metric.datasets).toEqual([
+          {
+            key: "|x|",
+            data: [1, 3],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            }
+          },
+          {
+            key: "a", //will have id 1
+            data: [2, null],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            },
+            agg: {
+              avg: [2, null],
+              min: [2, null],
+              max: [2, null],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          },
+          {
+            key: "a-mean", //will have id 2
+            data: [2, null],
+            derived: {
+              from: 1, //a will be 1
+              mode: "mean",
+              dataRaw: [{ x: "a", y: 2, z: 1 }, null]
+            },
+            agg: {
+              avg: [2, null],
+              min: [2, null],
+              max: [2, null],
+              count: 1,
+              total: 2
+            },
+            last: {
+              max: 2,
+              min: 2
+            }
+          },
+          {
+            key: "b", //will have id 3
+            data: [null, 4],
+            derived: {
+              from: -1,
+              mode: "",
+              dataRaw: []
+            },
+            agg: {
+              avg: [null, 4],
+              min: [null, 4],
+              max: [null, 4],
+              count: 1,
+              total: 4
+            },
+            last: {
+              max: 4,
+              min: 4
+            }
+          },
+          {
+            key: "b-mean",
+            data: [null, 4],
+            derived: {
+              from: 3,
+              mode: "mean",
+              dataRaw: [null, { x: "b", y: 4, z: 3 }]
+            },
+            agg: {
+              avg: [null, 4],
+              min: [null, 4],
+              max: [null, 4],
+              count: 1,
+              total: 4
+            },
+            last: {
+              max: 4,
+              min: 4
+            }
+          }
+        ])
+
+        chart.pushData([
+          { x: 'c', y: 6, z: 5 },
+          { x: 'a', y: 2, z: 7 }
+        ])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1, 3, 5, 7],
+          [2, null, null, 2],
+          [2, null, null, 2],
+          [null, 4, null, null],
+          [null, 4, null, null],
+          [null, null, 6, null],
+          [null, null, 6, null]
+        ])
+      })
+
+      test("mean numerics", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean"
+        })
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        chart.pushData([
+          { x: "a", y: 2, z: 1 },
+          { x: "a", y: 3, z: 2 },
+          { x: "a", y: 4, z: 3 },
+          { x: "a", y: 5, z: 4 },
+          { x: "a", y: 6, z: 5 },
+          { x: "a", y: -10, z: 6 },
+        ])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1,2,3,4,5,6],
+          [2,3,4,5,6,-10],
+          [2,2.5,3,3.5,4,10/6]
+        ])
+      })
+
+      test("percentile numerics", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "p50~p90"
+        })
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+
+        chart.pushData([
+          { x: "a", y: 2, z: 1 },
+          { x: "a", y: 4, z: 2 },
+          { x: "a", y: 3, z: 3 },
+          { x: "a", y: 3, z: 4 },
+          { x: "a", y: 4, z: 5 },
+          { x: "a", y: -7, z: 6 },
+        ])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1,2,3,4,5,6],
+          [2,4,3,3,4,-7],
+          [2,2,3,3,3,3], // 50th percentile
+          [2,2,3,3,4,4], // 90th percentile
+        ])
+      })
+
+      test("windowing timer filters old points", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean", deriveWindowSecs: 2})
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        chart.pushData([
+          { x: "a", y: 2, z: 1 },
+          { x: "a", y: 4, z: 2 },
+          { x: "a", y: 3, z: 3 },
+          { x: "a", y: 12, z: 8 },
+          { x: "a", y: 4, z: 10 },
+          { x: "a", y: -7, z: 22 },
+          { x: "a", y: 9, z: 24.1 },
+        ])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1,2,3,8,10,22,24.1],
+          [2,4,3,12,4,-7,9],
+          [2,3,3,12,8,-7,9], // mean of last 2 sec
+        ])
+      })
+
+      test("filters nulls", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean",
+        deriveWindowSecs: 2})
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        chart.pushData([
+          { x: "a", y: 2, z: 1 },
+          { x: "a", y: 4, z: 2 },
+          { x: "b", y: 3, z: 3 },
+          { x: "a", y: 12, z: 4 },
+          { x: "a", y: 4, z: 10 },
+          { x: "a", y: -7, z: 22 },
+          { x: "a", y: 9, z: 24.1 },
+        ])
+
+        expect(mockSetData).toHaveBeenCalledWith([
+          [1,2,3,4,10,22,24.1],
+          [2,4,null,12,4,-7,9], // a
+          [2,3,null,8,4,-7,9], // a: mean of last 2 sec
+          [null,null,3,null,null,null,null], // b
+          [null,null,3,null,null,null,null] // b: mean of last 2 sec
+        ])
+      })
+
+      test("is pruned", () => {
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "mean",
+         deriveWindowSecs: 1000, pruneThreshold: 2})
+        expect(mockDelSeries).toHaveBeenCalledTimes(1)
+
+        const dataToPush = [
+          { x: "a", y: 2, z: 1 },
+          { x: "a", y: 3, z: 2 },
+          { x: "a", y: 4, z: 3 },
+          { x: "a", y: 5, z: 4 },
+          { x: "a", y: 6, z: 5 },
+          { x: "a", y: 7, z: 6 },
+        ]
+        
+        //so that prune is called after each push
+        dataToPush.forEach(
+          d => {
+            chart.pushData([d])
+          }
+        )
+        
+        expect(mockSetData).toHaveBeenLastCalledWith([
+          [5,6],
+          [6,7], // a
+          [5,6] // a: mean of last 3 items because prune happens after measurement is computed
+        ])
+
+      })
+
+    })
+
   })
+    
 })
 
 describe("refresh interval", () => {

--- a/assets/test/metrics_live_test.js
+++ b/assets/test/metrics_live_test.js
@@ -996,7 +996,7 @@ describe('Metrics with tags', () => {
       })
 
       test("percentile numerics", () => {
-        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "p50~p90"
+        const chart = new TelemetryChart(document.body, { metric: "summary", tagged: true, deriveModes: "p50~p90~p0~p100"
         })
         expect(mockDelSeries).toHaveBeenCalledTimes(1)
 
@@ -1015,6 +1015,8 @@ describe('Metrics with tags', () => {
           [2,4,3,3,4,-7],
           [2,2,3,3,3,3], // 50th percentile
           [2,2,3,3,4,4], // 90th percentile
+          [2,2,2,2,2,-7], // 0th percentile
+          [2,4,4,4,4,4], // 100th percentile
         ])
       })
 

--- a/dev.exs
+++ b/dev.exs
@@ -161,7 +161,11 @@ defmodule DemoWeb.Telemetry do
       ),
       summary("phoenix.router_dispatch.stop.duration",
         tags: [:route],
-        unit: {:native, :millisecond}
+        unit: {:native, :millisecond},
+        reporter_options: [
+          derive_modes: ["p90", "mean"],
+          derive_window_secs: 180
+        ]
       ),
 
       # VM Metrics

--- a/lib/phoenix/live_dashboard/components/chart_component.ex
+++ b/lib/phoenix/live_dashboard/components/chart_component.ex
@@ -149,24 +149,31 @@ defmodule Phoenix.LiveDashboard.ChartComponent do
   defp validate_derive_modes(nil), do: nil
 
   defp validate_derive_modes(modes) do
-    :ok = Enum.each(
-      modes,
-      fn mode ->
-        unless mode == "mean" do
-          percentile = try do
-            {"p", value} = String.split_at(mode, 1)
-            String.to_integer(value)
-          rescue
-            _e -> raise ArgumentError, ":modes must be a list of strings. strings must be either 'mean' or 'pX' where X is an integer between 0 and 100, got: #{inspect(modes)}"
-          end
+    err_string = ":modes must be a list of strings. strings must be either 'mean' or 'pX' where X is an integer between 0 and 100, got: #{inspect(modes)}"
 
-          unless percentile >= 0 and percentile <= 100 do
-            raise ArgumentError,
-            ":modes included a percentile specification pX where x was outsize of the range 0-100, got: #{inspect(mode)}"
+    if is_list(modes) do
+      :ok = Enum.each(
+        modes,
+        fn mode ->
+          unless mode == "mean" do
+            percentile = try do
+              {"p", value} = String.split_at(mode, 1)
+              String.to_integer(value)
+            rescue
+              _e -> raise ArgumentError, err_string
+            end
+
+            unless percentile >= 0 and percentile <= 100 do
+              raise ArgumentError,
+              ":modes included a percentile specification pX where x was outsize of the range 0-100, got: #{inspect(mode)}"
+            end
           end
         end
-      end
-    )
+      )
+    else
+      raise ArgumentError, err_string
+    end
+
     modes
   end
 end

--- a/test/phoenix/live_dashboard/components/chart_component_test.exs
+++ b/test/phoenix/live_dashboard/components/chart_component_test.exs
@@ -68,6 +68,69 @@ defmodule Phoenix.LiveDashboard.ChartComponentTest do
       end
     end
 
+    test "adds derived modes" do
+      result = render_chart(
+        metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: ["p90","mean"]])
+      )
+
+      assert result =~ ~s|data-derive-modes="p90~mean"|
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: "p90"])
+        )
+      end
+
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: [90]])
+        )
+      end
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: ["p101"]])
+        )
+      end
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: ["p"]])
+        )
+      end
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_modes: ["other"]])
+        )
+      end
+
+      result = render_chart(
+        metric: summary([:a, :b, :c, :count], reporter_options: [derive_window_secs: 40])
+      )
+
+      assert result =~ ~s|data-derive-window-secs="40"|
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_window_secs: -1])
+        )
+      end
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_window_secs: 1.2])
+        )
+      end
+
+      assert_raise ArgumentError, fn ->
+        render_chart(
+          metric: summary([:a, :b, :c, :count], reporter_options: [derive_window_secs: :infinity])
+        )
+      end
+    end
+
     test "renders data" do
       result = render_chart(metric: last_value([:a, :b, :c, :count]), data: [{"x", "y", "z"}])
       assert result =~ ~s|<span data-x="x" data-y="y" data-z="z">|


### PR DESCRIPTION
**Summary:**
This commit adds the option to show rolling statistics as additional lines on the summary graph. Currently this can either be a rolling mean or percentile. The other aggregate statistics are preserved separately. This works for both tagged and untagged summary graphs. The feature is disabled by default.

Configuration is done with two new reporter_options like so:
```
summary("phoenix.router_dispatch.stop.duration",
        tags: [:route],
        unit: {:native, :millisecond},
        reporter_options: [
          derive_modes: ["p90", "mean"],
          derive_window_secs: 180
        ]
      )
```

The "mode" is either `"mean"` for mean, or `"pX"`, where X is an integer from 0-100, for a percentile. The statistic is computed over a backwards looking window that contains the last N seconds as set by `derive_window_secs`.

On the javascript side we register new series and dataset with `findOrCreateSeries()` and modify the dataset object to include information on which statistics to compute and which series the new dataset is derived from.

Incidentally, I think this addresses #245.

Feedback appreciated! Thanks!

**Test Plan:**
`metrics_live_test.js`: I added new unit tests to cover the derived series cases and updated the old tests to account for the new dataset object.
`chart_component_tests.exs`: New unit tests similar to the ones for the pruning option.
`dev.exs`: I put an example usage in dev.exs and tested end-to-end manually


**Example:**
![image](https://user-images.githubusercontent.com/6186388/152923217-edd74bd6-e5bf-42d9-89a3-957af375e67c.png)