### PR TITLE
Use Config, fixes compile warning

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :phoenix, :json_library, Jason
 config :phoenix, :stacktrace_depth, 20


### PR DESCRIPTION
Fixes Config compile warning

```
warning: use Mix.Config is deprecated. Use the Config module instead                                                                                                                                               
  config/config.exs:1                                                                                                                                                                                              
```