### PR TITLE
⚡ Improve first page load time when using metrics history

### DIFF
--- a/test/phoenix/live_dashboard/pages/metrics_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/metrics_page_test.exs
@@ -63,12 +63,15 @@ defmodule Phoenix.LiveDashboard.MetricsPageTest do
   end
 
   test "renders history for metrics" do
-    data = ~s|<span data-x="#{TestHistory.label()}" data-y="#{TestHistory.measurement()}"|
+    data1 = ~s|<span data-x="#{TestHistory.label1()}" data-y="#{TestHistory.measurement1()}"|
+    data2 = ~s|<span data-x="#{TestHistory.label2()}" data-y="#{TestHistory.measurement2()}"|
 
     {:ok, live, _} = live(build_conn(), "/dashboard/metrics?nav=phx")
-    refute render(live) =~ data
+    refute render(live) =~ data1
+    refute render(live) =~ data2
 
     {:ok, live, _} = live(build_conn(), "/config/nonode@nohost/metrics?nav=phx")
-    assert render(live) =~ data
+    assert render(live) =~ data1
+    assert render(live) =~ data2
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -100,11 +100,16 @@ defmodule Phoenix.LiveDashboardTest.Router do
 end
 
 defmodule TestHistory do
-  def label, do: "Z"
-  def measurement, do: 26
+  def label1, do: "Z"
+  def measurement1, do: 26
+  def label2, do: "X"
+  def measurement2, do: 27
 
   def test_data(_metric) do
-    [%{label: label(), measurement: measurement(), time: System.system_time(:microsecond)}]
+    [
+      %{label: label1(), measurement: measurement1(), time: System.system_time(:microsecond)},
+      %{label: label2(), measurement: measurement2(), time: System.system_time(:microsecond)}
+    ]
   end
 end
 


### PR DESCRIPTION
Hi, thanks for the dashboard, it is awesome💖

When using metrics history we observed that each item of history was sent as an individual update over the web socket after mounting which often lead to a long wait before the data was up to date and the page could respond to user input. This PR sends the history in chunks of up to 500 records. This number was picked because it seemed to be a good balance between getting the data over the wire and keeping the diffs small enough that the page is still responsive. It would be possible to make this number configurable, but I wanted to ask if there was any interest in the PR first. 

Thanks!