### PR TITLE
use csp_nonces on os_mon page

### DIFF
--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -86,8 +86,8 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
     )
   end
 
-  defp memory_usage_row(%{os_mon: os_mon}) do
-    params = memory_usage_params(os_mon)
+  defp memory_usage_row(%{os_mon: os_mon, csp_nonces: csp_nonces}) do
+    params = memory_usage_params(os_mon, csp_nonces)
 
     row(
       components: [
@@ -100,8 +100,8 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
     )
   end
 
-  defp disk_usage_row(%{os_mon: os_mon}) do
-    params = disk_usage_params(os_mon)
+  defp disk_usage_row(%{os_mon: os_mon, csp_nonces: csp_nonces}) do
+    params = disk_usage_params(os_mon, csp_nonces)
 
     row(
       title: "Disk",
@@ -115,16 +115,16 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
     )
   end
 
-  defp memory_usage_params(os_mon) do
+  defp memory_usage_params(os_mon, csp_nonces) do
     usages = calculate_memory_usage(os_mon.system_mem)
 
-    [title: "Memory", usages: usages, dom_id: "memory"]
+    [title: "Memory", usages: usages, dom_id: "memory", csp_nonces: csp_nonces]
   end
 
-  defp disk_usage_params(os_mon) do
+  defp disk_usage_params(os_mon, csp_nonces) do
     usages = calculate_disk_usage(os_mon.disk)
 
-    [title: "Disk", usages: usages, dom_id: "disk"]
+    [title: "Disk", usages: usages, dom_id: "disk", csp_nonces: csp_nonces]
   end
 
   defp calculate_memory_usage(system_memory) do


### PR DESCRIPTION
Hi!
Thanks for all the great work on this project!

I'm using `phoenix_live_dashboard` with CSP nonces enabled and `csp_nonce_assign_key` set in the dashboard configuration.
This works fine on, for example, the home page, but the progress/usage bars for Memory and Disk usage on the `OS Data` page fail, due to the inline `<style>` elements not using the CSP nonce.

This PR fixes this by passing the `csp_nonces` assign to the `usage_card` component, as it is already done on the home page.