### PR TITLE
Fix bootstrap warnings in dart-sass

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "bootstrap": "^4.4.1",
+        "bootstrap": "^4.6.2",
         "nprogress": "^0.2.0",
         "phoenix": "../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
@@ -38,13 +38,15 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.13",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.1.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1"
+      "version": "0.17.7",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.5.5",
@@ -2446,9 +2448,23 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -14619,9 +14635,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -24490,8 +24506,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -13,7 +13,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "bootstrap": "^4.4.1",
+    "bootstrap": "^4.6.2",
     "nprogress": "^0.2.0",
     "phoenix": "../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",


### PR DESCRIPTION
Note that I omitted the `dist` files as I remember only the core team checks those in. Let me know if I'm mistaken.

I Installed via:

```bash
$ npm --prefix assets install --legacy-peer-deps bootstrap@4.6.2
```

`--legacy-peer-deps` is needed, otherwise it will install JQuery and Popper.js

Fixes the following warnings

<img width="1189" alt="Screen Shot 2022-07-20 at 8 32 22 AM" src="https://user-images.githubusercontent.com/1019721/179984889-dfb261a6-996e-4f05-bf63-165195941983.png">
