### PR TITLE
Ecto Repos Page - Migrations

### DIFF
--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -43,10 +43,29 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
   end
 
   @impl true
-  def menu_link(%{repos: []}, _capabilities), do: :skip
 
-  def menu_link(%{repos: _}, _capabilities) do
-    {:ok, @page_title}
+  def menu_link(%{repos: []}, _capabilities) do
+    :skip
+  end
+
+  @impl true
+  def menu_link(%{repos: :auto_discover}, _caps) do
+    # We require the extras plugins to be on this node,
+    # which means we also require Ecto.Adapters.SQL on this node.
+    if Code.ensure_loaded?(Ecto.Adapters.SQL) do
+      {:ok, @page_title}
+    else
+      :skip
+    end
+  end
+
+  @impl true
+  def menu_link(%{repos: repos}, capabilities) do
+    if Enum.all?(repos, fn repo -> repo not in capabilities.processes end) do
+      :skip
+    else
+      {:disabled, @page_title}
+    end
   end
 
   @impl true

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -1,7 +1,6 @@
 defmodule Phoenix.LiveDashboard.EctoReposPage do
   @moduledoc false
   use Phoenix.LiveDashboard.PageBuilder
-  import Phoenix.LiveDashboard.Helpers
 
   @compile {:no_warn_undefined, [{Ecto.Repo, :all_running, 0}]}
   @page_title "Ecto Repos"
@@ -107,9 +106,9 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
 
   defp render_migrations(repo, table_name) do
     columns = [
-      %{field: :status, sortable: :asc, format: &format(:string, &1)},
-      %{field: :name, sortable: :asc, format: &format(:string, &1)},
-      %{field: :number, sortable: :asc, format: &format(:string, &1)}
+      %{field: :status, sortable: :asc},
+      %{field: :name, sortable: :asc},
+      %{field: :number, sortable: :asc}
     ]
 
     searchable = [:name]
@@ -154,18 +153,6 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
 
     {sorted, length(sorted)}
   end
-
-  defp format(_, %struct{} = value) when struct in [Decimal, Postgrex.Interval],
-    do: struct.to_string(value)
-
-  defp format(:bytes, value) when is_integer(value),
-    do: format_bytes(value)
-
-  defp format(:percent, value) when is_number(value),
-    do: value |> Kernel.*(100.0) |> Float.round(1) |> Float.to_string()
-
-  defp format(_type, value),
-    do: value
 
   defp auto_discover(node) do
     case :rpc.call(node, Ecto.Repo, :all_running, []) do

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -187,11 +187,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
           ~H"""
           <small>
             No Ecto repository was found running on this node.
-            Currently only PSQL and MySQL databases are supported.
-
-            Depending on the database Ecto PSQL Extras or Ecto MySQL Extras should be installed.
-
-            Check the <a href="https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html" target="_blank">documentation</a> for details.
+            Currently only Postgres and MySQL databases are supported.
           </small>
           """
 

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -68,7 +68,6 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
              render_repo_tab(%{
                repo: repo,
                node: current_node,
-               # TODO do we need?
                ecto_options: assigns.ecto_options
              })
            end}

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -1,0 +1,198 @@
+defmodule Phoenix.LiveDashboard.EctoReposPage do
+  @moduledoc false
+  use Phoenix.LiveDashboard.PageBuilder
+  import Phoenix.LiveDashboard.Helpers
+
+  @compile {:no_warn_undefined, [{Ecto.Repo, :all_running, 0}]}
+  @page_title "Ecto Repos"
+
+  @impl true
+  def init(%{
+        repos: repos,
+        ecto_migrations_paths: ecto_migrations_paths
+      }) do
+    capabilities = for repo <- List.wrap(repos), do: {:process, repo}
+    repos = repos || :auto_discover
+
+    {:ok,
+     %{
+       repos: repos,
+       ecto_options: [
+         ecto_migrations_paths: ecto_migrations_paths
+       ]
+     }, capabilities}
+  end
+
+  @impl true
+  def mount(_params, %{repos: repos, ecto_options: ecto_options}, socket) do
+    socket = assign(socket, ecto_options: ecto_options)
+
+    result =
+      case repos do
+        :auto_discover ->
+          auto_discover(socket.assigns.page.node)
+
+        [_ | _] = repos ->
+          {:ok, repos}
+
+        _ ->
+          {:error, :no_ecto_repos_available}
+      end
+
+    case result do
+      {:ok, repos} ->
+        {:ok, assign(socket, :repos, repos)}
+
+      {:error, error} ->
+        {:ok, assign(socket, :error, error)}
+    end
+  end
+
+  @impl true
+  def menu_link(%{repos: _}, _capabilities) do
+    {:ok, @page_title}
+  end
+
+  @impl true
+  def render_page(assigns) do
+    if assigns[:error] do
+      render_error(assigns)
+    else
+      current_node = assigns.page.node
+
+      items =
+        for repo <- assigns.repos do
+          {repo,
+           name: inspect(repo),
+           render: fn ->
+             render_repo_tab(%{
+               repo: repo,
+               node: current_node,
+               # TODO do we need?
+               ecto_options: assigns.ecto_options
+             })
+           end}
+        end
+
+      nav_bar(items: items, nav_param: :repo, extra_params: [:nav], style: :bar)
+    end
+  end
+
+  defp render_repo_tab(assigns) do
+    nav_bar(items: items(assigns), extra_params: [:repo])
+  end
+
+  defp items(%{repo: repo, ecto_options: ecto_options}) do
+    for tab <- [:migrations] do
+      {tab,
+       name: Phoenix.Naming.humanize(tab),
+       render: fn ->
+         render_migrations(repo, tab, ecto_options)
+       end}
+    end
+  end
+
+  defp render_migrations(repo, table_name, ecto_options) do
+    columns = [
+      %{field: :status, sortable: :asc, format: &format(:string, &1)},
+      %{field: :name, sortable: :asc, format: &format(:string, &1)},
+      %{field: :number, sortable: :asc, format: &format(:string, &1)}
+    ]
+
+    searchable = [:name]
+    default_sort_by = :number
+
+    table(
+      id: :table_id,
+      hint: "Database migrations for #{inspect(repo)}",
+      limit: false,
+      default_sort_by: default_sort_by,
+      search: searchable != [],
+      columns: columns,
+      rows_name: "entries",
+      row_fetcher: &row_fetcher(repo, searchable, ecto_options, &1, &2),
+      title: Phoenix.Naming.humanize(table_name)
+    )
+  end
+
+  defp row_fetcher(repo, searchable, ecto_options, params, _node) do
+    %{search: search, sort_by: sort_by, sort_dir: sort_dir} = params
+
+    migrations =
+      case Keyword.get(ecto_options, :ecto_migrations_paths, []) do
+        [] -> Ecto.Migrator.migrations(repo)
+        locations -> Ecto.Migrator.migrations(repo, locations)
+      end
+
+    mapped =
+      migrations
+      |> Enum.map(fn {status, number, name} ->
+        %{status: status, number: number, name: Phoenix.Naming.humanize(name)}
+      end)
+
+    filtered =
+      if search do
+        Enum.filter(mapped, fn map ->
+          Enum.any?(searchable, fn column ->
+            value = Map.fetch!(map, column)
+            value && value =~ search
+          end)
+        end)
+      else
+        mapped
+      end
+
+    sorted = Enum.sort_by(filtered, fn row -> row[sort_by] end, sort_dir)
+
+    {sorted, length(sorted)}
+  end
+
+  defp format(_, %struct{} = value) when struct in [Decimal, Postgrex.Interval],
+    do: struct.to_string(value)
+
+  defp format(:bytes, value) when is_integer(value),
+    do: format_bytes(value)
+
+  defp format(:percent, value) when is_number(value),
+    do: value |> Kernel.*(100.0) |> Float.round(1) |> Float.to_string()
+
+  defp format(_type, value),
+    do: value
+
+  defp auto_discover(node) do
+    case :rpc.call(node, Ecto.Repo, :all_running, []) do
+      repos when is_list(repos) ->
+        {:ok, repos}
+
+      {:badrpc, _error} ->
+        {:error, :cannot_list_running_repos}
+    end
+  end
+
+  defp render_error(assigns) do
+    error_message =
+      case assigns.error do
+        :no_ecto_repos_available ->
+          ~H"""
+          <small>
+            No Ecto repository was found running on this node.
+            Currently only PSQL and MySQL databases are supported.
+
+            Depending on the database Ecto PSQL Extras or Ecto MySQL Extras should be installed.
+
+            Check the <a href="https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html" target="_blank">documentation</a> for details.
+          </small>
+          """
+
+        :cannot_list_running_repos ->
+          ~H"""
+          <small>
+            Cannot list running repositories.
+            Make sure that Ecto is running with version ~> 3.7.
+          </small>
+          """
+      end
+
+    card(value: error_message)
+  end
+end

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -169,6 +169,9 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
 
   defp auto_discover(node) do
     case :rpc.call(node, Ecto.Repo, :all_running, []) do
+      [] ->
+        {:error, :no_ecto_repos_available}
+
       repos when is_list(repos) ->
         {:ok, repos}
 

--- a/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_repos_page.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
 
     {:ok,
      %{
-       repos: repos,
+       repos: repos
      }, capabilities}
   end
 
@@ -43,6 +43,8 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
   end
 
   @impl true
+  def menu_link(%{repos: []}, _capabilities), do: :skip
+
   def menu_link(%{repos: _}, _capabilities) do
     {:ok, @page_title}
   end
@@ -61,7 +63,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPage do
            render: fn ->
              render_repo_tab(%{
                repo: repo,
-               node: current_node,
+               node: current_node
              })
            end}
         end

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -333,7 +333,8 @@ defmodule Phoenix.LiveDashboard.Router do
     ecto_session = %{
       repos: ecto_repos(ecto_repos),
       ecto_psql_extras_options: ecto_psql_extras_options,
-      ecto_mysql_extras_options: ecto_mysql_extras_options
+      ecto_mysql_extras_options: ecto_mysql_extras_options,
+      ecto_migrations_paths: ["../../bitfo/brain/priv/repo/migrations"]
     }
 
     {pages, requirements} =
@@ -349,6 +350,7 @@ defmodule Phoenix.LiveDashboard.Router do
         ports: {Phoenix.LiveDashboard.PortsPage, %{}},
         sockets: {Phoenix.LiveDashboard.SocketsPage, %{}},
         ets: {Phoenix.LiveDashboard.EtsPage, %{}},
+        ecto_repos: {Phoenix.LiveDashboard.EctoReposPage, ecto_session},
         ecto_stats: {Phoenix.LiveDashboard.EctoStatsPage, ecto_session}
       )
       |> Enum.concat(additional_pages)

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -333,8 +333,7 @@ defmodule Phoenix.LiveDashboard.Router do
     ecto_session = %{
       repos: ecto_repos(ecto_repos),
       ecto_psql_extras_options: ecto_psql_extras_options,
-      ecto_mysql_extras_options: ecto_mysql_extras_options,
-      ecto_migrations_paths: ["../../bitfo/brain/priv/repo/migrations"]
+      ecto_mysql_extras_options: ecto_mysql_extras_options
     }
 
     {pages, requirements} =

--- a/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
+++ b/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
@@ -14,16 +14,16 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
     assert :skip = EctoReposPage.menu_link(%{repos: []}, %{})
     assert :skip = EctoReposPage.menu_link(%{repos: [Repo]}, %{processes: []})
 
-    assert {:ok, "Ecto Stats"} = EctoReposPage.menu_link(%{repos: [Repo]}, %{processes: [Repo]})
+    assert {:disabled, "Ecto Repos"} = EctoReposPage.menu_link(%{repos: [Repo]}, %{processes: [Repo]})
 
-    assert {:ok, "Ecto Stats"} =
+    assert {:ok, "Ecto Repos"} =
              EctoReposPage.menu_link(%{repos: :auto_discover}, %{processes: []})
   end
 
   test "renders" do
     start_main_repo!()
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    {:ok, live, _} = live(build_conn(), ecto_repos_path())
     rendered = render(live)
 
     assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
@@ -33,7 +33,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
 
     start_pg_repo!()
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    {:ok, live, _} = live(build_conn(), ecto_repos_path())
     rendered = render(live)
 
     assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
@@ -41,7 +41,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
 
     start_mysql_repo!()
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    {:ok, live, _} = live(build_conn(), ecto_repos_path())
     rendered = render(live)
 
     assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
@@ -50,7 +50,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
   end
 
   test "renders error without running repos" do
-    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    {:ok, live, _} = live(build_conn(), ecto_repos_path())
     rendered = render(live)
 
     refute rendered =~ "Phoenix.LiveDashboardTest.Repo"
@@ -73,13 +73,13 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
     start_main_repo!()
 
     for {nav, _} <- EctoPSQLExtras.queries(Repo), nav not in @forbidden_navs do
-      assert {:ok, _, _} = live(build_conn(), ecto_stats_path(nav))
+      assert {:ok, _, _} = live(build_conn(), ecto_repos_path(nav))
     end
 
     start_mysql_repo!()
 
     for {nav, _} <- EctoMySQLExtras.queries(MySQLRepo) do
-      assert {:ok, _, _} = live(build_conn(), ecto_stats_path(nav))
+      assert {:ok, _, _} = live(build_conn(), ecto_repos_path(nav))
     end
 
     start_pg_repo!()
@@ -89,7 +89,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
 
     nav = Enum.random(available_navs)
 
-    assert {:ok, live, _} = live(build_conn(), ecto_stats_path(nav, "", PGRepo))
+    assert {:ok, live, _} = live(build_conn(), ecto_repos_path(nav, "", PGRepo))
 
     assert live
            |> element("a.active", "Phoenix.LiveDashboardTest.PGRepo")
@@ -110,14 +110,14 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
   test "search" do
     start_main_repo!()
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path(:extensions))
+    {:ok, live, _} = live(build_conn(), ecto_repos_path(:extensions))
     rendered = render(live)
     assert rendered =~ "Default version"
     assert rendered =~ "Installed version"
     assert rendered =~ "fuzzystrmatch"
     assert rendered =~ "hstore"
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path(:extensions, "hstore"))
+    {:ok, live, _} = live(build_conn(), ecto_repos_path(:extensions, "hstore"))
     rendered = render(live)
     assert rendered =~ "Default version"
     assert rendered =~ "Installed version"
@@ -126,7 +126,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
 
     start_mysql_repo!()
 
-    {:ok, live, _} = live(build_conn(), ecto_stats_path(:plugins, "", MySQLRepo))
+    {:ok, live, _} = live(build_conn(), ecto_repos_path(:plugins, "", MySQLRepo))
 
     rendered = render(live)
     assert rendered =~ "Version"
@@ -137,7 +137,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
     {:ok, live, _} =
       live(
         build_conn(),
-        ecto_stats_path(:plugins, "InnoDB", MySQLRepo)
+        ecto_repos_path(:plugins, "InnoDB", MySQLRepo)
       )
 
     rendered = render(live)
@@ -147,31 +147,31 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
     assert rendered =~ "InnoDB"
   end
 
-  defp ecto_stats_path() do
-    "/dashboard/ecto_stats"
+  defp ecto_repos_path() do
+    "/dashboard/ecto_repos"
   end
 
-  defp ecto_stats_path(nav) do
-    "#{ecto_stats_path()}?nav=#{nav}"
+  defp ecto_repos_path(nav) do
+    "#{ecto_repos_path()}?nav=#{nav}"
   end
 
-  defp ecto_stats_path(nav, search) do
-    "#{ecto_stats_path()}?nav=#{nav}&search=#{search}"
+  defp ecto_repos_path(nav, search) do
+    "#{ecto_repos_path()}?nav=#{nav}&search=#{search}"
   end
 
-  defp ecto_stats_path(nav, search, repo) do
-    "#{ecto_stats_path()}?nav=#{nav}&search=#{search}&repo=#{repo}"
+  defp ecto_repos_path(nav, search, repo) do
+    "#{ecto_repos_path()}?nav=#{nav}&search=#{search}&repo=#{repo}"
   end
 
   defp start_main_repo! do
-    start_supervised!(Repo)
+    start_supervised(Repo)
   end
 
   defp start_pg_repo! do
-    start_supervised!(PGRepo)
+    start_supervised(PGRepo)
   end
 
   defp start_mysql_repo! do
-    start_supervised!(MySQLRepo)
+    start_supervised(MySQLRepo)
   end
 end

--- a/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
+++ b/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
@@ -59,13 +59,7 @@ defmodule Phoenix.LiveDashboard.EctoReposPageTest do
     assert rendered =~
              "No Ecto repository was found running on this node."
 
-    assert rendered =~ "Currently only PSQL and MySQL databases are supported."
-
-    assert rendered =~
-             "Depending on the database Ecto PSQL Extras or Ecto MySQL Extras should be installed."
-
-    assert rendered =~
-             ~s|Check the <a href="https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html" target="_blank">documentation</a> for details|
+    assert rendered =~ "Currently only Postgres and MySQL databases are supported."
   end
 
   test "navs" do

--- a/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
+++ b/test/phoenix/live_dashboard/pages/ecto_repos_test.exs
@@ -1,0 +1,177 @@
+defmodule Phoenix.LiveDashboard.EctoReposPageTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  @endpoint Phoenix.LiveDashboardTest.Endpoint
+
+  alias Phoenix.LiveDashboard.EctoReposPage
+  alias Phoenix.LiveDashboardTest.Repo
+  alias Phoenix.LiveDashboardTest.PGRepo
+  alias Phoenix.LiveDashboardTest.MySQLRepo
+
+  test "menu_link/2" do
+    assert :skip = EctoReposPage.menu_link(%{repos: []}, %{})
+    assert :skip = EctoReposPage.menu_link(%{repos: [Repo]}, %{processes: []})
+
+    assert {:ok, "Ecto Stats"} = EctoReposPage.menu_link(%{repos: [Repo]}, %{processes: [Repo]})
+
+    assert {:ok, "Ecto Stats"} =
+             EctoReposPage.menu_link(%{repos: :auto_discover}, %{processes: []})
+  end
+
+  test "renders" do
+    start_main_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    rendered = render(live)
+
+    assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
+    refute rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
+    refute rendered =~ "Phoenix.LiveDashboardTest.MySQLRepo"
+    assert rendered =~ ~r"Showing \d+ entries"
+
+    start_pg_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    rendered = render(live)
+
+    assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
+
+    start_mysql_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    rendered = render(live)
+
+    assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.MySQLRepo"
+  end
+
+  test "renders error without running repos" do
+    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    rendered = render(live)
+
+    refute rendered =~ "Phoenix.LiveDashboardTest.Repo"
+
+    assert rendered =~
+             "No Ecto repository was found running on this node."
+
+    assert rendered =~ "Currently only PSQL and MySQL databases are supported."
+
+    assert rendered =~
+             "Depending on the database Ecto PSQL Extras or Ecto MySQL Extras should be installed."
+
+    assert rendered =~
+             ~s|Check the <a href="https://hexdocs.pm/phoenix_live_dashboard/ecto_stats.html" target="_blank">documentation</a> for details|
+  end
+
+  @forbidden_navs [:kill_all, :mandelbrot]
+
+  test "navs" do
+    start_main_repo!()
+
+    for {nav, _} <- EctoPSQLExtras.queries(Repo), nav not in @forbidden_navs do
+      assert {:ok, _, _} = live(build_conn(), ecto_stats_path(nav))
+    end
+
+    start_mysql_repo!()
+
+    for {nav, _} <- EctoMySQLExtras.queries(MySQLRepo) do
+      assert {:ok, _, _} = live(build_conn(), ecto_stats_path(nav))
+    end
+
+    start_pg_repo!()
+
+    available_navs =
+      for {nav, _} <- EctoPSQLExtras.queries(PGRepo), nav not in @forbidden_navs, do: nav
+
+    nav = Enum.random(available_navs)
+
+    assert {:ok, live, _} = live(build_conn(), ecto_stats_path(nav, "", PGRepo))
+
+    assert live
+           |> element("a.active", "Phoenix.LiveDashboardTest.PGRepo")
+           |> has_element?()
+
+    another_nav = Enum.random(available_navs -- [nav])
+
+    live
+    |> element(~s|a.nav-link[href*='nav=#{another_nav}']|)
+    |> render_click()
+
+    # Keep the same repo selected
+    assert live
+           |> element("a.active", "Phoenix.LiveDashboardTest.PGRepo")
+           |> has_element?()
+  end
+
+  test "search" do
+    start_main_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path(:extensions))
+    rendered = render(live)
+    assert rendered =~ "Default version"
+    assert rendered =~ "Installed version"
+    assert rendered =~ "fuzzystrmatch"
+    assert rendered =~ "hstore"
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path(:extensions, "hstore"))
+    rendered = render(live)
+    assert rendered =~ "Default version"
+    assert rendered =~ "Installed version"
+    refute rendered =~ "fuzzystrmatch"
+    assert rendered =~ "hstore"
+
+    start_mysql_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path(:plugins, "", MySQLRepo))
+
+    rendered = render(live)
+    assert rendered =~ "Version"
+    assert rendered =~ "Status"
+    assert rendered =~ "PERFORMANCE_SCHEMA"
+    assert rendered =~ "InnoDB"
+
+    {:ok, live, _} =
+      live(
+        build_conn(),
+        ecto_stats_path(:plugins, "InnoDB", MySQLRepo)
+      )
+
+    rendered = render(live)
+    assert rendered =~ "Version"
+    assert rendered =~ "Status"
+    refute rendered =~ "PERFORMANCE_SCHEMA"
+    assert rendered =~ "InnoDB"
+  end
+
+  defp ecto_stats_path() do
+    "/dashboard/ecto_stats"
+  end
+
+  defp ecto_stats_path(nav) do
+    "#{ecto_stats_path()}?nav=#{nav}"
+  end
+
+  defp ecto_stats_path(nav, search) do
+    "#{ecto_stats_path()}?nav=#{nav}&search=#{search}"
+  end
+
+  defp ecto_stats_path(nav, search, repo) do
+    "#{ecto_stats_path()}?nav=#{nav}&search=#{search}&repo=#{repo}"
+  end
+
+  defp start_main_repo! do
+    start_supervised!(Repo)
+  end
+
+  defp start_pg_repo! do
+    start_supervised!(PGRepo)
+  end
+
+  defp start_mysql_repo! do
+    start_supervised!(MySQLRepo)
+  end
+end

--- a/test/phoenix/live_dashboard/pages/ecto_stats_test.exs
+++ b/test/phoenix/live_dashboard/pages/ecto_stats_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
@@ -164,14 +164,14 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
   end
 
   defp start_main_repo! do
-    start_supervised!(Repo)
+    start_supervised(Repo)
   end
 
   defp start_pg_repo! do
-    start_supervised!(PGRepo)
+    start_supervised(PGRepo)
   end
 
   defp start_mysql_repo! do
-    start_supervised!(MySQLRepo)
+    start_supervised(MySQLRepo)
   end
 end

--- a/test/phoenix/live_dashboard/router_test.exs
+++ b/test/phoenix/live_dashboard/router_test.exs
@@ -295,6 +295,7 @@ defmodule Phoenix.LiveDashboard.RouterTest do
                  ports: {Phoenix.LiveDashboard.PortsPage, %{}},
                  sockets: {Phoenix.LiveDashboard.SocketsPage, %{}},
                  ets: {Phoenix.LiveDashboard.EtsPage, %{}},
+                 ecto_repos: {Phoenix.LiveDashboard.EctoReposPage, %{repos: :auto_discover}},
                  ecto_stats:
                    {Phoenix.LiveDashboard.EctoStatsPage,
                     %{


### PR DESCRIPTION
After [some discussion](https://twitter.com/mcrumm/status/1548085608001654785?s=20&t=Dlcv0mOz6hLRdOFYyS_fRw) on twitter, this PR adds a new tab, `Ecto Repos`, that shows database migrations for each repo.

In the future, we can add additional functionality, such as running migrations, if `:allow_destructive_actions` is set.

**Outstanding**
- [x] Validate that we want this as a separate tab
- [x] Validate passing a global `:ecto_migrations_path`, as opposed to one per repo. Answer: We'll start with no config
- [x] Question: Is it safe to cast the migration number to a `NaiveDateTime`? Answer: No
- [x] Write tests once the above is stabilized


<img width="1299" alt="Screen Shot 2022-07-20 at 10 25 59 AM" src="https://user-images.githubusercontent.com/1019721/180007102-9b9b28f3-94fe-4a64-a2ee-2dc9e5794321.png">
s