### PR TITLE
Document PageBuilder.table/1 title as required and row_attrs options

### DIFF
--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -276,6 +276,10 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     * `:rows_name` - A string to name the representation of the rows.
       Default is calculated from the current page.
 
+    * `:row_attrs` - A function that return a list with HTML attributes for the table row. It
+      receive the row as argument and return a list of 2 element tuple with HTML attribute name
+      and value. The default function returns an empty list `[]`.
+
     * `:default_sort_by` - The default columnt to sort by to.
       Defaults to the first sortable column.
 

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -279,8 +279,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     * `:default_sort_by` - The default columnt to sort by to.
       Defaults to the first sortable column.
 
-    * `:title` - The title of the table.
-      Default is calculated with the current page.
+    * `:title` - Required. The title of the table.
 
     * `:limit` - A list of integers to limit the number of rows to show.
       Default: `[50, 100, 500, 1000, 5000]`. May be set to `false` to disable the `limit`.


### PR DESCRIPTION
Address issue: #376.

Mark `title` option as required and add documentation for `row_attrs` option for `table/1`.