### PR TITLE
Allow latest ecto version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Phoenix.LiveDashboard.MixProject do
       {:telemetry_metrics, "~> 0.6.0"},
       {:ecto_psql_extras, "~> 0.7", optional: true},
       {:ecto_mysql_extras, "~> 0.5", optional: true},
-      {:ecto, "~> 3.6.2 or ~> 3.7", optional: true},
+      {:ecto, "~> 3.6.2 or ~> 3.7 or ~> 3.8", optional: true},
 
       # Dev and test
       {:circular_buffer, "~> 0.3", only: :dev},


### PR DESCRIPTION
Ecto 3.8 is out and currently `phoenix_live_dashboard` suppresses upgrading without an `override: true`, this relaxes the ecto requirement to allow upgrading seemlessly.

Is there anything I need to add to test this? I've verified it works with my local copy but I'm hardly a representative sample.

thanks!