### PR TITLE
Fix links on ports page

### DIFF
--- a/lib/phoenix/live_dashboard/info/port_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/port_info_component.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
             <tr><td>Input</td><td><pre><%= format_bytes(@input) %></pre></td></tr>
             <tr><td>Output</td><td><pre><%= format_bytes(@output) %></pre></td></tr>
             <tr><td>OS pid</td><td><pre><%= @os_pid %></pre></td></tr>
-            <tr><td>Links</td><td><pre><%= @links %></pre></td></tr>
+            <tr><td>Links</td><td><pre><.info links={@links} /></pre></td></tr>
           </tbody>
         </table>
       <% else %>
@@ -69,4 +69,11 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
        do: val
 
   defp format_info(_key, val, live_dashboard_path), do: format_value(val, live_dashboard_path)
+  defp info(%{links: links} = assigns) when is_list(links) do
+    ~H"""
+    <%= for info <- @links do %><%= info %><% end %>
+    """
+  end
+
+  defp info(%{links: _links} = assigns), do: ~H|<%= @links %>|
 end

--- a/lib/phoenix/live_dashboard/info/port_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/port_info_component.ex
@@ -69,6 +69,7 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
        do: val
 
   defp format_info(_key, val, live_dashboard_path), do: format_value(val, live_dashboard_path)
+
   defp info(%{links: links} = assigns) when is_list(links) do
     ~H"""
     <%= for info <- @links do %><%= info %><% end %>


### PR DESCRIPTION
Currently showing details of a Port with links crashes the LiveView with:

```
[error] GenServer #PID<0.1590.0> terminating
** (ArgumentError) lists in Phoenix.HTML and templates may only contain integers representing bytes, binaries or other lists, got invalid entry: %Phoenix.LiveView.Rendered{static: ["<a", ">", "</a>"], dynamic: #Function<1.69459183/1 in Phoenix.LiveView.Helpers.live_link/3>, fingerprint: 86902442242554815241208945448020438717, root: true, caller: :not_available}
    (phoenix_html 3.2.0) lib/phoenix_html/safe.ex:81: Phoenix.HTML.Safe.List.to_iodata/1
    (phoenix_html 3.2.0) lib/phoenix_html/safe.ex:49: Phoenix.HTML.Safe.List.to_iodata/1
    (phoenix_live_dashboard 0.7.1) lib/phoenix/live_dashboard/info/port_info_component.ex:29: anonymous fn/2 in Phoenix.LiveDashboard.PortInfoComponent.render/1
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:521: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
    (elixir 1.14.1) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:691: Phoenix.LiveView.Diff.render_component/9
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:636: anonymous fn/5 in Phoenix.LiveView.Diff.render_pending_components/6
    (elixir 1.14.1) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (stdlib 4.1.1) maps.erl:411: :maps.fold_1/3
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:609: Phoenix.LiveView.Diff.render_pending_components/6
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:145: Phoenix.LiveView.Diff.render/3
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/channel.ex:810: Phoenix.LiveView.Channel.render_diff/3
    (phoenix_live_view 0.18.2) lib/phoenix_live_view/channel.ex:666: Phoenix.LiveView.Channel.handle_changed/4
    (stdlib 4.1.1) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.1.1) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

This fixes the links in the ports page (by using `.info` function component as in the `ProcessInfoComponent`)
