### PR TITLE
Back to render/1 callback and new docs

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -229,7 +229,7 @@ defmodule DemoWeb.GraphShowcasePage do
   end
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_nav_bar id="navbar" page={@page}>
       <:item name="Simple">

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -89,7 +89,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   ## Options for the use macro
 
-  The following options can be given when `use`ing the `PageBuilder` module:
+  The following options can be given when using the `PageBuilder` module:
 
   * `refresher?` - Boolean to enable or disable the automatic refresh in the page.
 

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -3,10 +3,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   Page builder is the default mechanism for building custom dashboard pages.
 
   Each dashboard page is a LiveView with additional callbacks for
-  customizing the menu appearance. One notable difference, however,
-  is that a page implements a `render_page/1` callback, which must
-  return one or more page builder components, instead of a `render/1`
-  callback that returns `~H` or `~L` (deprecated).
+  customizing the menu appearance and the automatic refresh.
 
   A simple and straight-forward example of a custom page is the
   `Phoenix.LiveDashboard.EtsPage` that ships with the dashboard:
@@ -21,15 +18,33 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
         end
 
         @impl true
-        def render_page(_assigns) do
-          table(
-            columns: table_columns(),
-            id: :ets_table,
-            row_attrs: &row_attrs/1,
-            row_fetcher: &fetch_ets/2,
-            rows_name: "tables",
-            title: "ETS"
-          )
+        def render(assigns) do
+          ~H\"""
+          <.live_table
+            id="table"
+            page={@page}
+            title="ETS"
+            row_fetcher={&fetch_ets/2}
+            row_attrs={&row_attrs/1}
+            rows_name="tables"
+          >
+            <:col
+              field={:name}
+              header="Name or module"
+              header_attrs={[class: "pl-4"]}
+              cell_attrs={[class: "pl-4"]}
+            />
+            <:col field={:protection} />
+            <:col field={:type} />
+            <:col field={:size} cell_attrs={[class: "text-right"]} sortable={:desc} />
+            <:col field={:memory} cell_attrs={[class: "tabular-column-bytes"]} sortable={:desc} :let={ets}>
+              <%= format_words(ets[:memory]) %>
+            </:col>
+            <:col field={:owner} :let={ets} >
+              <%= encode_pid(ets[:owner]) %>
+            </:col>
+          </.live_table>
+          \"""
         end
 
         defp fetch_ets(params, node) do
@@ -42,35 +57,6 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
           # the current entries (up to limit) and an integer with the
           # total amount of entries.
           # ...
-        end
-
-        defp table_columns() do
-          [
-            %{
-              field: :name,
-              header: "Name or module",
-            },
-            %{
-              field: :protection
-            },
-            %{
-              field: :type
-            },
-            %{
-              field: :size,
-              cell_attrs: [class: "text-right"],
-              sortable: :desc
-            },
-            %{
-              field: :memory,
-              format: &format_words/1,
-              sortable: :desc
-            },
-            %{
-              field: :owner,
-              format: &encode_pid/1
-            }
-          ]
         end
 
         defp row_attrs(table) do
@@ -101,13 +87,21 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   callback. If not tuple is given, `c:init/1` will receive an empty
   list.
 
+  ## Options for the use macro
+
+  The following options can be given when `use`ing the `PageBuilder` module:
+
+  * `refresher?` - Boolean to enable or disable the automatic refresh in the page.
+
   ## Components
 
-  A page can only have the components listed with this page.
+  A page can return any valid HEEx template in the `render/1` callback,
+  and it can use the components listed with this page too.
 
-  We currently support `card/1`, `columns/1`, `fields_card/1`,
-  `live_layered_graph/1`, `live_nav_bar/1`, `row/1`, `shared_usage_card/1`, `live_table/1`,
-  and `usage_card/1`.
+  We currently support `card/1`, `fields_card/1`, `row/1`,
+  `shared_usage_card/1`, and `usage_card/1`;
+  and the live components `live_layered_graph/1`, `live_nav_bar/1`, 
+  and `live_table/1`.
 
   ## Helpers
 
@@ -193,7 +187,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   @callback mount(unsigned_params(), session(), socket :: Socket.t()) ::
               {:ok, Socket.t()} | {:ok, Socket.t(), keyword()}
 
-  @callback render_page(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
+  @callback render(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
 
   @callback handle_params(unsigned_params(), uri :: String.t(), socket :: Socket.t()) ::
               {:noreply, Socket.t()}
@@ -214,6 +208,9 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   @callback handle_info(msg :: term, socket :: Socket.t()) ::
               {:noreply, Socket.t()}
 
+  @doc """
+  Callback invoked when the automatic refresh is enabled.
+  """
   @callback handle_refresh(socket :: Socket.t()) ::
               {:noreply, Socket.t()}
 

--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -227,13 +227,8 @@ defmodule Phoenix.LiveDashboard.PageLive do
     """
   end
 
-  defp render_page(module, assigns)
-       when module in [Phoenix.LiveDashboard.RequestLoggerPage] do
+  defp render_page(module, assigns) do
     module.render(assigns)
-  end
-
-  defp render_page(module, page_assigns) do
-    module.render_page(page_assigns)
   end
 
   defp live_info(_, %{info: nil}), do: nil

--- a/lib/phoenix/live_dashboard/pages/applications_page.ex
+++ b/lib/phoenix/live_dashboard/pages/applications_page.ex
@@ -7,7 +7,7 @@ defmodule Phoenix.LiveDashboard.ApplicationsPage do
   @menu_text "Applications"
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_table
       id="table"

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -131,7 +131,7 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   end
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     if assigns[:error] do
       render_error(assigns)
     else

--- a/lib/phoenix/live_dashboard/pages/ets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ets_page.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveDashboard.EtsPage do
   @menu_text "ETS"
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_table
       id="table"

--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -67,7 +67,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
   end
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.row>
       <:col>

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -57,7 +57,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
   end
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_nav_bar id="metrics_nav_bar" page={@page} >
       <:item :for={item <- @items} name={item} label={format_nav_name(item)} method="redirect">

--- a/lib/phoenix/live_dashboard/pages/os_mon_page.ex
+++ b/lib/phoenix/live_dashboard/pages/os_mon_page.ex
@@ -109,7 +109,7 @@ defmodule Phoenix.LiveDashboard.OSMonPage do
   end
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.row>
       <:col>

--- a/lib/phoenix/live_dashboard/pages/ports_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ports_page.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveDashboard.PortsPage do
   @menu_text "Ports"
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_table
       id="table"

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
   @menu_text "Processes"
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_table
       id="table"

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -70,8 +70,6 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
   end
 
   @impl true
-  def render_page(_assigns), do: raise("this page is special cased to use render/2 instead")
-
   def render(assigns) do
     ~H"""
     <!-- Card containing log messages -->

--- a/lib/phoenix/live_dashboard/pages/sockets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/sockets_page.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.LiveDashboard.SocketsPage do
   @menu_text "Sockets"
 
   @impl true
-  def render_page(assigns) do
+  def render(assigns) do
     ~H"""
     <.live_table
       id="table"


### PR DESCRIPTION
Now that we return HEEx templates in the `render_page/1` callback, I think it makes sense to go back to the regular `render/1` callback. If you think it is a bad idea, I can revert it.

I updated the docs, but I am not a native English speaker, so suggestions are more than welcome 🤣 