### PR TITLE
Remove class attr from components

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -36,4 +36,6 @@
 @import "./app/utils/resource_usage";
 @import "./app/utils/tabular_info";
 
+@import "./app/pages";
+
 @import "./app/liveview";

--- a/assets/css/app/_pages.scss
+++ b/assets/css/app/_pages.scss
@@ -1,0 +1,51 @@
+/* Apps */
+.apps-table-version {
+  @extend .px-4;
+}
+
+/* ETS */
+.ets-table-memory {
+  @extend .tabular-column-bytes;
+}
+
+/* Ports */
+.ports-table-port {
+  @extend .tabular-column-id;
+}
+
+.ports-table-name {
+  @extend .w-50;
+}
+
+td.ports-table-input {
+  @extend .tabular-column-bytes;
+}
+
+.ports-table-output {
+  @extend .tabular-column-bytes;
+  @extend .pr-4;
+}
+
+/* Processes */
+.processes-table-name_or_initial_call {
+  @extend .tabular-column-name;
+}
+
+.processes-table-current_function {
+  @extend .tabular-column-name;
+}
+
+
+/* Sockets */
+td.sockets-table-port {
+  @extend .tabular-column-name;
+  @extend .tabular-column-id;
+}
+
+.sockets-table-send_oct, .sockets-table-recv_oct {
+  @extend .pr-4;
+}
+
+td.sockets-table-send_oct, td.sockets-table-recv_oct {
+  @extend .tabular-column-bytes;
+}

--- a/assets/css/app/components/_backgrounds.scss
+++ b/assets/css/app/components/_backgrounds.scss
@@ -1,14 +1,17 @@
 // Colorful backgrounds that can be used across the app
-.bg-elixir {
+#elixir-card {
   background: linear-gradient(40deg, $color-elixir, $color-elixir-accent);
+  color: #fff;
 }
 
-.bg-phoenix {
+#phoenix-card {
   background: linear-gradient(40deg, $color-phoenix, $color-phoenix-accent);
+  color: #fff;
 }
 
-.bg-dashboard {
+#app-card {
   background: linear-gradient(40deg, $color-dashboard, $color-dashboard-accent);
+  color: #fff;
 }
 
 .bg-green {

--- a/assets/css/app/components/_banner_card.scss
+++ b/assets/css/app/components/_banner_card.scss
@@ -16,7 +16,7 @@
   margin-bottom: -0.15rem;
 }
 
-.no-title .banner-card-value {
+#system-info-card .banner-card-value {
   font-size: 16px;
   font-weight: 400;
   padding: 0.3rem;

--- a/assets/css/app/extends/_tables.scss
+++ b/assets/css/app/extends/_tables.scss
@@ -2,6 +2,10 @@ tr[phx-click]{
   cursor: pointer;
 }
 
+tr>:first-child {
+  @extend .pl-4;
+}
+
 table.table-hover tbody tr:hover {
   background-color: $color-gray-100;
 }

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -21,23 +21,19 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
         def render(assigns) do
           ~H\"""
           <.live_table
-            id="table"
+            id="ets-table"
+            dom_id="ets-table"
             page={@page}
             title="ETS"
             row_fetcher={&fetch_ets/2}
             row_attrs={&row_attrs/1}
             rows_name="tables"
           >
-            <:col
-              field={:name}
-              header="Name or module"
-              header_attrs={[class: "pl-4"]}
-              cell_attrs={[class: "pl-4"]}
-            />
+            <:col field={:name} header="Name or module" />
             <:col field={:protection} />
             <:col field={:type} />
-            <:col field={:size} cell_attrs={[class: "text-right"]} sortable={:desc} />
-            <:col field={:memory} cell_attrs={[class: "tabular-column-bytes"]} sortable={:desc} :let={ets}>
+            <:col field={:size} text_align="right" sortable={:desc} />
+            <:col field={:memory} text_align="right" sortable={:desc} :let={ets}>
               <%= format_words(ets[:memory]) %>
             </:col>
             <:col field={:owner} :let={ets} >
@@ -244,21 +240,9 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     attr :header, :string,
       doc: "Label to show in the current column. Default value is calculated from `:field`."
 
-    attr :header_attrs, :any,
-      doc: """
-      A list with HTML attributes for the column header.
-      It can be also a function that receive the column as argument
-      and returns a list of 2 element tuple with HTML attribute name
-      and value. Default to `[]`.
-      """
-
-    attr :cell_attrs, :any,
-      doc: """
-      A list with HTML attributes for the table cell.
-      It can be also a function that receive the row as argument
-      and returns a list of 2 element tuple with HTML attribute name
-      and value. Default to `[]`.
-      """
+    attr :text_align, :string,
+      values: ~w[left center right justify],
+      doc: "Text align for text in the column. Default: `nil`."
   end
 
   attr :row_fetcher, :any,
@@ -302,6 +286,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     doc: "A boolean indicating if the search functionality is enabled."
 
   attr :hint, :string, default: nil, doc: "A textual hint to show close to the title."
+  attr :dom_id, :string, default: nil, doc: "id attribute for the HTML the main tag."
   @spec live_table(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
   def live_table(assigns) do
     ~H"""
@@ -400,16 +385,13 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   attr :hint, :string, default: nil, doc: "A textual hint to show close to the title."
   attr :inner_title, :string, default: nil, doc: "The title inside the card."
   attr :inner_hint, :string, default: nil, doc: "A textual hint to show close to the inner title."
-
-  attr :class, :string,
-    default: "",
-    doc: "Additional css classes that will be added along banner-card class."
+  attr :dom_id, :string, default: nil, doc: "id attribute for the HTML the main tag."
 
   @spec card(assigns :: Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
   def card(assigns) do
     ~H"""
     <.card_title title={@title} hint={@hint} />
-    <div class={"banner-card mt-auto #{@class}"}>
+    <div id={@dom_id} class="banner-card mt-auto">
       <h6 class="banner-card-title" :if={@inner_title}>
         <%= @inner_title %>
         <.hint :if={@inner_hint} text={@inner_hint} />
@@ -530,7 +512,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     <div class="card">
       <div class="card-body card-usage">
         <%= for usage <- @usage do %>
-          <.title_bar_component dom_id={"#{@dom_id}-#{usage.dom_sub_id}"} class="py-2" percent={usage.percent} csp_nonces={@csp_nonces} >
+          <.title_bar_component dom_id={"#{@dom_id}-#{usage.dom_sub_id}"} percent={usage.percent} csp_nonces={@csp_nonces} >
             <div>
               <%= usage.title %>
               <.hint text={usage[:hint]} :if={usage[:hint]}/>
@@ -551,7 +533,6 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
   end
 
   @doc false
-  attr :class, :string, default: ""
   attr :color, :string, default: "blue"
   attr :dom_id, :string, required: true
   attr :percent, :float, required: true
@@ -560,7 +541,7 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
 
   defp title_bar_component(assigns) do
     ~H"""
-    <div class={@class}>
+    <div class="py-2">
       <section>
         <div class="d-flex justify-content-between">
           <%= render_slot @inner_block %>

--- a/lib/phoenix/live_dashboard/pages/applications_page.ex
+++ b/lib/phoenix/live_dashboard/pages/applications_page.ex
@@ -10,24 +10,20 @@ defmodule Phoenix.LiveDashboard.ApplicationsPage do
   def render(assigns) do
     ~H"""
     <.live_table
-      id="table"
+      id="apps-table"
+      dom_id="apps-table"
       page={@page}
       title="Applications"
       row_fetcher={&fetch_applications/2}
       row_attrs={&row_attrs/1}
     >
-      <:col
-        field={:name}
-        sortable={:asc}
-        header_attrs={[class: "pl-4"]}
-        cell_attrs={[class: "pl-4"]}
-      />
+      <:col field={:name} sortable={:asc} />
       <:col field={:description} />
       <:col field={:state} sortable={:asc} />
-      <:col field={:tree?} header="Sup tree?" cell_attrs={[class: "text-center"]} :let={app}>
+      <:col field={:tree?} header="Sup tree?" text_align="center" :let={app}>
         <%= if app[:tree?], do: "✓" %>
       </:col>
-      <:col field={:version} header_attrs={[class: "px-4"]} cell_attrs={[class: "px-4"]}/>
+      <:col field={:version} />
     </.live_table>
     """
   end

--- a/lib/phoenix/live_dashboard/pages/ets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ets_page.ex
@@ -11,23 +11,19 @@ defmodule Phoenix.LiveDashboard.EtsPage do
   def render(assigns) do
     ~H"""
     <.live_table
-      id="table"
+      id="ets-table"
+      dom_id="ets-table"
       page={@page}
       title="ETS"
       row_fetcher={&fetch_ets/2}
       row_attrs={&row_attrs/1}
       rows_name="tables"
     >
-      <:col
-        field={:name}
-        header="Name or module"
-        header_attrs={[class: "pl-4"]}
-        cell_attrs={[class: "pl-4"]}
-      />
+      <:col field={:name} header="Name or module" />
       <:col field={:protection} />
       <:col field={:type} />
-      <:col field={:size} cell_attrs={[class: "text-right"]} sortable={:desc} />
-      <:col field={:memory} cell_attrs={[class: "tabular-column-bytes"]} sortable={:desc} :let={ets}>
+      <:col field={:size} text_align="right" sortable={:desc} />
+      <:col field={:memory} text_align="right" sortable={:desc} :let={ets}>
         <%= format_words(ets[:memory]) %>
       </:col>
       <:col field={:owner} :let={ets} >

--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -118,7 +118,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
     ~H"""
     <.row>
       <:col>
-        <.card title="System information" class="no-title">
+        <.card dom_id="system-info-card" title="System information">
           <%= "#{@banner} [#{@system_architecture}]" %>
         </.card>
       </:col>
@@ -135,17 +135,17 @@ defmodule Phoenix.LiveDashboard.HomePage do
     ~H"""
     <.row>
       <:col>
-        <.card inner_title="Elixir" class="bg-elixir text-white">
+        <.card dom_id="elixir-card" inner_title="Elixir">
           <%= @elixir_version %>
         </.card>
       </:col>
       <:col>
-        <.card inner_title="Phoenix" class="bg-phoenix text-white">
+        <.card dom_id="phoenix-card" inner_title="Phoenix">
           <%= @phoenix_version %>
         </.card>
       </:col>
       <:col>
-        <.card inner_title={@app_title} class="bg-dashboard text-white">
+        <.card dom_id="app-card" inner_title={@app_title}>
           <%= @app_version %>
         </.card>
       </:col>

--- a/lib/phoenix/live_dashboard/pages/ports_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ports_page.ex
@@ -11,26 +11,17 @@ defmodule Phoenix.LiveDashboard.PortsPage do
   def render(assigns) do
     ~H"""
     <.live_table
-      id="table"
+      id="ports-table"
+      dom_id="ports-table"
       page={@page}
       title="Ports"
       row_fetcher={&fetch_ports/2}
       row_attrs={&row_attrs/1}
     >
-      <:col
-        field={:port}
-        header_attrs={[class: "pl-4"]}
-        cell_attrs={[class: "tabular-column-id pl-4"]}
-        :let={data}
-      >
+      <:col field={:port} :let={data}>
         <%= data[:port] |> encode_port() |> String.trim_leading("Port") %>
       </:col>
-      <:col
-        field={:name}
-        header="Name or path"
-        cell_attrs={[class: "w-50"]}
-        :let={data}
-      >
+      <:col field={:name} header="Name or path" :let={data}>
         <%= format_path(data[:name]) %>
       </:col>
       <:col
@@ -40,30 +31,14 @@ defmodule Phoenix.LiveDashboard.PortsPage do
       >
         <%= if data[:os_pid] != :undefined, do: data[:os_pid] %>
       </:col>
-      <:col
-        field={:input}
-        header_attrs={[class: "text-right"]}
-        cell_attrs={[class: "tabular-column-bytes"]}
-        sortable={:desc}
-        :let={data}
-      >
+      <:col field={:input} text_align="right" sortable={:desc} :let={data}>
         <%= format_bytes(data[:input]) %>
       </:col>
-      <:col
-        field={:output}
-        header_attrs={[class: "text-right pr-4"]}
-        cell_attrs={[class: "tabular-column-bytes pr-4"]}
-        sortable={:desc}
-        :let={data}
-      >
+      <:col field={:output} text_align="right" sortable={:desc} :let={data}>
         <%= format_bytes(data[:output]) %>
       </:col>
-      <:col
-        field={:id}
-        header_attrs={[class: "text-right"]}
-        cell_attrs={[class: "text-right"]}
-      />
-      <:col field={:owner} :let={data} >
+      <:col field={:id} text_align="right"/>
+      <:col field={:owner} :let={data}>
         <%= inspect(data[:owner]) %>
       </:col>
     </.live_table>

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -11,56 +11,23 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
   def render(assigns) do
     ~H"""
     <.live_table
-      id="table"
+      id="processes-table"
+      dom_id="processes-table"
       page={@page}
       row_fetcher={{&fetch_processes/3, nil}}
       row_attrs={&row_attrs/1}
       title="Processes"
     >
-      <:col
-        field={:pid}
-        header="PID"
-        header_attrs={[class: "pl-4"]}
-        cell_attrs={[class: "tabular-column-id pl-4"]}
-        :let={process}
-      >
+      <:col field={:pid} header="PID" :let={process} >
         <%= process[:pid] |> encode_pid() |> String.replace_prefix("PID", "") %>
       </:col>
-      <:col
-        field={:name_or_initial_call}
-        header="Name or initial call"
-        cell_attrs={[class: "tabular-column-name"]}
-      />
-      <:col
-        field={:memory}
-        header="Memory"
-        header_attrs={[class: "text-right"]}
-        cell_attrs={[class: "text-right"]}
-        sortable={:desc}
-        :let={process}
-      >
+      <:col field={:name_or_initial_call} header="Name or initial call"/>
+      <:col field={:memory} header="Memory" text_align="right" sortable={:desc} :let={process}>
         <%= format_bytes(process[:memory]) %>
       </:col>
-      <:col
-        field={:reductions_diff}
-        header={"Reductions"}
-        header_attrs={[class: "text-right"]}
-        cell_attrs={[class: "text-right"]}
-        sortable={:desc}
-      />
-      <:col
-        field={:message_queue_len}
-        header={"MsgQ"}
-        header_attrs={[class: "text-right"]}
-        cell_attrs={[class: "text-right"]}
-        sortable={:desc}
-        />
-      <:col
-        field={:current_function}
-        header={"Current function"}
-        cell_attrs={[class: "tabular-column-current"]}
-        :let={process}
-      >
+      <:col field={:reductions_diff} header="Reductions" text_align="right" sortable={:desc}/>
+      <:col field={:message_queue_len} header="MsgQ" text_align="right" sortable={:desc}/>
+      <:col field={:current_function} header="Current function" :let={process}>
         <%= format_call(process[:current_function]) %>
       </:col>
     </.live_table>

--- a/lib/phoenix/live_dashboard/pages/sockets_page.ex
+++ b/lib/phoenix/live_dashboard/pages/sockets_page.ex
@@ -11,39 +11,21 @@ defmodule Phoenix.LiveDashboard.SocketsPage do
   def render(assigns) do
     ~H"""
     <.live_table
-      id="table"
+      id="sockets-table"
+      dom_id="sockets-table"
       page={@page}
       title="Sockets"
       row_fetcher={&fetch_sockets/2}
       row_attrs={&row_attrs/1}
     >
-      <:col
-        field={:port}
-        header_attrs={[class: "pl-4"]}
-        cell_attrs={[class: "tabular-column-name tabular-column-id pl-4"]}
-        :let={socket}
-      >
+      <:col field={:port} :let={socket}>
         <%= socket[:port] |> encode_socket() |> String.trim_leading("Socket") %>
       </:col>
       <:col field={:module} sortable={:asc} />
-      <:col
-        field={:send_oct}
-        header={"Sent"}
-        header_attrs={[class: "text-right pr-4"]}
-        cell_attrs={[class: "tabular-column-bytes pr-4"]}
-        sortable={:desc}
-        :let={socket}
-      >
+      <:col field={:send_oct} header="Sent" text_align="right" sortable={:desc} :let={socket}>
         <%= format_bytes(socket[:send_oct]) %>
       </:col>
-      <:col
-        field={:recv_oct}
-        header={"Received"}
-        header_attrs={[class: "text-right pr-4"]}
-        cell_attrs={[class: "tabular-column-bytes pr-4"]}
-        sortable={:desc}
-        :let={socket}
-      >
+      <:col field={:recv_oct} header="Received" text_align="right" sortable={:desc} :let={socket}>
         <%= format_bytes(socket[:recv_oct]) %>
       </:col>
       <:col field={:local_address} header="Local Address" sortable={:asc} />

--- a/test/phoenix/live_dashboard/components/table_component_test.exs
+++ b/test/phoenix/live_dashboard/components/table_component_test.exs
@@ -36,6 +36,7 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
     Map.merge(
       %{
         id: :component_id,
+        dom_id: :component_id,
         page: page,
         row_fetcher: &row_fetcher/2,
         title: "Title"
@@ -102,37 +103,36 @@ defmodule Phoenix.LiveDashboard.TableComponentTest do
               <:col 
                 field={:foo}
                 header="Foo header"
-                header_attrs={[class: "header-foo-class"]}
                 sortable={:desc}
-                cell_attrs={fn _ -> [class: "cell-foo-class"] end}
                 :let={row}
               >
                 <%= "foo-format-#{row[:foo]}" %>
               </:col>
-              <:col field={:bar} cell_attrs={[class: "cell-bar-class"]} />
-              <:col field={:baz} />
+              <:col field={:bar} text_align="right"/>
+              <:col field={:baz}/>
             </.live_component>
             """
           end,
-          default_assigns(),
+          default_assigns(dom_id: "qux"),
           router: Router
         )
 
       assert result =~ "Foo header"
       assert result =~ "Bar"
       assert result =~ "Baz"
-      assert result =~ ~r|<th>[\r\n\s]*Baz[\r\n\s]*</th>|
 
-      assert result =~ ~s|<th class=\"header-foo-class\">|
+      assert result =~ ~s|<th class="qux-foo">|
+      assert result =~ ~s|<th class="qux-bar text-right">|
+      assert result =~ ~r|<th class="qux-baz">[\r\n\s]*Baz[\r\n\s]*</th>|
 
-      assert result =~ ~r|<td class=\"cell-foo-class\">[\r\n\s]*foo-format-1[\r\n\s]*</td>|
-      assert result =~ ~r|<td class=\"cell-foo-class\">[\r\n\s]*foo-format-4[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-foo">[\r\n\s]*foo-format-1[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-foo">[\r\n\s]*foo-format-4[\r\n\s]*</td>|
 
-      assert result =~ ~r|<td class=\"cell-bar-class\">[\r\n\s]*2[\r\n\s]*</td>|
-      assert result =~ ~r|<td class=\"cell-bar-class\">[\r\n\s]*5[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-bar text-right">[\r\n\s]*2[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-bar text-right">[\r\n\s]*5[\r\n\s]*</td>|
 
-      assert result =~ ~r|<td>[\r\n\s]*3[\r\n\s]*</td>|
-      assert result =~ ~r|<td>[\r\n\s]*6[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-baz">[\r\n\s]*3[\r\n\s]*</td>|
+      assert result =~ ~r|<td class="qux-baz">[\r\n\s]*6[\r\n\s]*</td>|
     end
 
     test "renders title" do

--- a/test/phoenix/live_dashboard/page_builder_test.exs
+++ b/test/phoenix/live_dashboard/page_builder_test.exs
@@ -12,7 +12,6 @@ defmodule Phoenix.LiveDashboard.PageBuilderTest do
       <.card
         title="test-title"
         hint="test-hint"
-        class="test-class-1 test-class-2"
         inner_title="test-inner-title"
         inner_hint="test-inner-hint"
       >test-value</.card>
@@ -20,7 +19,7 @@ defmodule Phoenix.LiveDashboard.PageBuilderTest do
 
     assert result =~ ~r|<h5 class=\"card-title\">[\r\n\s]*test-title[\r\n\s]*|
     assert result =~ ~S|<div class="hint-text">test-hint</div>|
-    assert result =~ ~S|<div class="banner-card mt-auto test-class-1 test-class-2">|
+    assert result =~ ~S|<div class="banner-card mt-auto">|
     assert result =~ ~r|<h6 class=\"banner-card-title\">[\r\n\s]*test-inner-title[\r\n\s]*|
     assert result =~ ~S|<div class="hint-text">test-inner-hint</div>|
     assert result =~ ~r|<div class="banner-card-value">[\r\n\s]*test-value[\r\n\s]*</div>|


### PR DESCRIPTION
Hi,

This PR removes the usage of `class` for the components. We wanted to do it in a previous PR, but I didn't find a way to do it. It will also be helpful for #402 if we finally think it is a good idea. It may be a controversial solution, but I think the result is better than what was there before.

I couldn't remove the `live_table.row_attrs` function attr. The applications page uses it in a very complex way: https://github.com/phoenixframework/phoenix_live_dashboard/blob/v0.7.2/lib/phoenix/live_dashboard/pages/applications_page.ex#L60-L77
I believe it is ok to keep it for the moment. 