### PR TITLE
Custom modals

### DIFF
--- a/lib/phoenix/live_dashboard/info/app_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/app_info_component.ex
@@ -1,9 +1,16 @@
 defmodule Phoenix.LiveDashboard.AppInfoComponent do
-  use Phoenix.LiveDashboard.Web, :live_component
+  use Phoenix.LiveDashboard.Modal
 
   alias Phoenix.LiveDashboard.{PageBuilder, SystemInfo, ReingoldTilford}
 
-  @impl true
+  @impl Phoenix.LiveDashboard.Modal
+  def decode_params("App<" <> app) do
+    {:ok, app |> String.replace_suffix(">", "") |> String.to_existing_atom()}
+  end
+
+  def decode_params(_), do: :error
+
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="app-info">
@@ -27,14 +34,8 @@ defmodule Phoenix.LiveDashboard.AppInfoComponent do
     """
   end
 
-  @impl true
-  def mount(socket) do
-    {:ok, socket}
-  end
-
-  @impl true
-  def update(%{id: "App<" <> app, page: page}, socket) do
-    app = app |> String.replace_suffix(">", "") |> String.to_existing_atom()
+  @impl Phoenix.LiveComponent
+  def update(%{value: app, page: page}, socket) do
     {:ok, socket |> assign(app: app, node: page.node) |> assign_tree()}
   end
 

--- a/lib/phoenix/live_dashboard/info/ets_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/ets_info_component.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.EtsInfoComponent do
-  use Phoenix.LiveDashboard.Web, :live_component
+  use Phoenix.LiveDashboard.Modal
 
   alias Phoenix.LiveDashboard.SystemInfo
 
@@ -20,7 +20,14 @@ defmodule Phoenix.LiveDashboard.EtsInfoComponent do
     :protection
   ]
 
-  @impl true
+  @impl Phoenix.LiveDashboard.Modal
+  def decode_params("ETS" <> ref) do
+    {:ok, :erlang.list_to_ref(String.to_charlist("#Ref" <> ref))}
+  end
+
+  def decode_params(_), do: :error
+
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="tabular-info">
@@ -48,15 +55,13 @@ defmodule Phoenix.LiveDashboard.EtsInfoComponent do
     """
   end
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def mount(socket) do
     {:ok, Enum.reduce(@info_keys, socket, &assign(&2, &1, nil))}
   end
 
-  @impl true
-  def update(%{id: "ETS" <> ref, path: path, page: page}, socket) do
-    ref = :erlang.list_to_ref(String.to_charlist("#Ref" <> ref))
-
+  @impl Phoenix.LiveComponent
+  def update(%{value: ref, path: path, page: page}, socket) do
     {:ok, socket |> assign(ref: ref, path: path, node: page.node) |> assign_info()}
   end
 

--- a/lib/phoenix/live_dashboard/info/modal.ex
+++ b/lib/phoenix/live_dashboard/info/modal.ex
@@ -1,0 +1,19 @@
+defmodule Phoenix.LiveDashboard.Modal do
+  @type param() :: binary()
+  @type decoded_param() :: term()
+  @callback decode_params(param()) :: {:ok, decoded_param()} | :error
+  @callback title(param(), decoded_param()) :: binary()
+  @optional_callbacks title: 2
+
+  defmacro __using__(opts) do
+    quote location: :keep, bind_quoted: [opts: opts] do
+      use Phoenix.LiveDashboard.Web, :live_component
+      @behaviour Phoenix.LiveDashboard.Modal
+
+      @impl Phoenix.LiveDashboard.Modal
+      def title(param, _), do: param
+
+      defoverridable title: 2
+    end
+  end
+end

--- a/lib/phoenix/live_dashboard/info/modal_component.ex
+++ b/lib/phoenix/live_dashboard/info/modal_component.ex
@@ -1,6 +1,7 @@
 defmodule Phoenix.LiveDashboard.ModalComponent do
   use Phoenix.LiveDashboard.Web, :live_component
   alias Phoenix.LiveView.JS
+  alias Phoenix.LiveDashboard.PageBuilder
 
   defp enable_fullscreen() do
     JS.hide()
@@ -16,6 +17,7 @@ defmodule Phoenix.LiveDashboard.ModalComponent do
     |> JS.add_class("modal-dialog", to: "#modal-container")
   end
 
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div id={@id} class="dash-modal modal"
@@ -36,7 +38,9 @@ defmodule Phoenix.LiveDashboard.ModalComponent do
               <span phx-click={disable_fullscreen()} class="modal-action-item mr-3" id="fullscreen-off" style="display: none;">
                  &#128471;&#xFE0E;
               </span>
-              <.link patch={@return_to} class="modal-action-item mt-n1" id="modal-close">&times;</.link>
+              <.link patch={close_modal_path(@socket, @page)}
+                     class="modal-action-item mt-n1"
+                     id="modal-close">&times;</.link>
             </div>
           </div>
           <div class="modal-body">
@@ -48,7 +52,10 @@ defmodule Phoenix.LiveDashboard.ModalComponent do
     """
   end
 
+  @impl Phoenix.LiveComponent
   def handle_event("close", _, socket) do
-    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+    {:noreply, PageBuilder.close_modal(socket, socket.assigns.page)}
   end
+
+  defp close_modal_path(socket, page), do: PageBuilder.close_modal_path(socket, page)
 end

--- a/lib/phoenix/live_dashboard/info/port_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/port_info_component.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.PortInfoComponent do
-  use Phoenix.LiveDashboard.Web, :live_component
+  use Phoenix.LiveDashboard.Modal
 
   alias Phoenix.LiveDashboard.SystemInfo
 
@@ -13,7 +13,14 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
     :os_pid
   ]
 
-  @impl true
+  @impl Phoenix.LiveDashboard.Modal
+  def decode_params("Port" <> _ = port) do
+    {:ok, :erlang.list_to_port(String.to_charlist("#" <> port))}
+  end
+
+  def decode_params(_), do: :error
+
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="tabular-info">
@@ -34,14 +41,13 @@ defmodule Phoenix.LiveDashboard.PortInfoComponent do
     """
   end
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def mount(socket) do
     {:ok, Enum.reduce(@info_keys, socket, &assign(&2, &1, nil))}
   end
 
-  @impl true
-  def update(%{id: "Port" <> _ = port, path: path}, socket) do
-    port = :erlang.list_to_port(String.to_charlist("#" <> port))
+  @impl Phoenix.LiveComponent
+  def update(%{value: port, path: path}, socket) do
     {:ok, socket |> assign(port: port, path: path) |> assign_info()}
   end
 

--- a/lib/phoenix/live_dashboard/info/process_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/process_info_component.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
-  use Phoenix.LiveDashboard.Web, :live_component
+  use Phoenix.LiveDashboard.Modal
 
   alias Phoenix.LiveDashboard.SystemInfo
 
@@ -25,12 +25,18 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
     :current_stacktrace
   ]
 
-  @impl true
+  @impl Phoenix.LiveDashboard.Modal
+  def decode_params("PID" <> pid) do
+    {:ok, :erlang.list_to_pid(String.to_charlist(pid))}
+  end
+
+  def decode_params(_), do: :error
+  @impl Phoenix.LiveComponent
   def mount(socket) do
     {:ok, Enum.reduce(@info_keys, socket, &assign(&2, &1, nil))}
   end
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="tabular-info">
@@ -70,10 +76,8 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
     """
   end
 
-  @impl true
-  def update(%{id: "PID" <> pid, path: path, return_to: return_to, page: page}, socket) do
-    pid = :erlang.list_to_pid(String.to_charlist(pid))
-
+  @impl Phoenix.LiveComponent
+  def update(%{value: pid, path: path, return_to: return_to, page: page}, socket) do
     {:ok,
      socket |> assign(pid: pid, path: path, page: page, return_to: return_to) |> assign_info()}
   end

--- a/lib/phoenix/live_dashboard/info/socket_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/socket_info_component.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.LiveDashboard.SocketInfoComponent do
-  use Phoenix.LiveDashboard.Web, :live_component
+  use Phoenix.LiveDashboard.Modal
   alias Phoenix.LiveDashboard.SystemInfo
 
   @info_keys [
@@ -13,7 +13,13 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
     :connected
   ]
 
-  @impl true
+  @impl Phoenix.LiveDashboard.Modal
+  def decode_params("Socket" <> port) do
+    {:ok, :erlang.list_to_port(String.to_charlist("#Port" <> port))}
+  end
+
+  def decode_params(_), do: :error
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="tabular-info">
@@ -35,14 +41,13 @@ defmodule Phoenix.LiveDashboard.SocketInfoComponent do
     """
   end
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def mount(socket) do
     {:ok, Enum.reduce(@info_keys, socket, &assign(&2, &1, nil))}
   end
 
-  @impl true
-  def update(%{id: "Socket" <> port, path: path}, socket) do
-    port = :erlang.list_to_port(String.to_charlist("#Port" <> port))
+  @impl Phoenix.LiveComponent
+  def update(%{value: port, path: path}, socket) do
     {:ok, socket |> assign(:port, port) |> assign(:path, path) |> assign_info()}
   end
 

--- a/lib/phoenix/live_dashboard/page_builder.ex
+++ b/lib/phoenix/live_dashboard/page_builder.ex
@@ -778,18 +778,13 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
     doc: "Because is a stateful `Phoenix.LiveComponent` an unique id is needed."
 
   attr :title, :string, required: true, doc: "Title of the modal"
+  attr :page, __MODULE__, required: true, doc: "Dashboard page"
 
-  attr :return_to, :string, required: true, doc: "Path to return when closing the modal"
   slot(:inner_block, required: true, doc: "Content to show in the modal")
 
   def live_modal(assigns) do
     ~H"""
-    <.live_component
-      module={Phoenix.LiveDashboard.ModalComponent}
-      id={@id}
-      title={@title}
-      return_to={@return_to}
-    >
+    <.live_component module={Phoenix.LiveDashboard.ModalComponent} id={@id} title={@title} page={@page}>
       <%= render_slot @inner_block %>
     </.live_component>
     """
@@ -921,6 +916,21 @@ defmodule Phoenix.LiveDashboard.PageBuilder do
         end
       )
     end
+  end
+
+  @doc """
+  Close current modal
+  """
+  def close_modal(socket, %__MODULE__{} = page) do
+    Phoenix.LiveView.push_patch(socket, to: close_modal_path(socket, page))
+  end
+
+  @doc """
+  Path to close the current modal
+  """
+  def close_modal_path(socket, %__MODULE__{} = page) do
+    new_params = Map.delete(page.params, "info")
+    live_dashboard_path(socket, page.route, page.node, page.params, new_params)
   end
 
   defmacro __using__(opts) do

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -72,6 +72,8 @@ defmodule Phoenix.LiveDashboard.Router do
 
     * `:additional_pages` - A keyword list of additional pages
 
+    * `:additional_modals` - A list of additional `Phoenix.LiveDashboard.Modal`
+
   ## Examples
 
       defmodule MyAppWeb.Router do
@@ -217,6 +219,13 @@ defmodule Phoenix.LiveDashboard.Router do
           raise ArgumentError, ":additional_pages must be a keyword, got: " <> inspect(other)
       end
 
+    additional_modals =
+      case options[:additional_modals] do
+        nil -> []
+        modals when is_list(modals) -> modals
+        other -> raise ArgumentError, ":additional_modals must be a list, got: " <> inspect(other)
+      end
+
     request_logger_cookie_domain =
       case options[:request_logger_cookie_domain] do
         nil ->
@@ -315,6 +324,7 @@ defmodule Phoenix.LiveDashboard.Router do
       metrics,
       metrics_history,
       additional_pages,
+      additional_modals,
       request_logger,
       ecto_repos,
       ecto_psql_extras_options,
@@ -363,6 +373,7 @@ defmodule Phoenix.LiveDashboard.Router do
         metrics,
         metrics_history,
         additional_pages,
+        additional_modals,
         request_logger,
         ecto_repos,
         ecto_psql_extras_options,
@@ -399,8 +410,19 @@ defmodule Phoenix.LiveDashboard.Router do
       end)
       |> Enum.unzip()
 
+    modals =
+      additional_modals ++
+        [
+          Phoenix.LiveDashboard.AppInfoComponent,
+          Phoenix.LiveDashboard.ProcessInfoComponent,
+          Phoenix.LiveDashboard.PortInfoComponent,
+          Phoenix.LiveDashboard.SocketInfoComponent,
+          Phoenix.LiveDashboard.EtsInfoComponent
+        ]
+
     %{
       "pages" => pages,
+      "modals" => modals,
       "allow_destructive_actions" => allow_destructive_actions,
       "requirements" => requirements |> Enum.concat() |> Enum.uniq(),
       "csp_nonces" => %{


### PR DESCRIPTION
Define a behaviour for modals so external libraries can define their custom modals, and even, override the current ones. Current modals are changed to use the same behaviour, so there is no difference between an "external" or an internal modal.

We can include helpers in PageBuilder to show and close the modal easily.

WIP