### PR TITLE
Filtered process list

### DIFF
--- a/lib/phoenix/live_dashboard/info/process_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/process_info_component.ex
@@ -35,7 +35,7 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
 
     if process_filter_mod = Application.get_env(:phoenix_live_dashboard, :process_filter, nil) do
       filter = assigns.page.params["filter"]
-      filter && process_filter_mod.render(Map.put(assigns, :filter, filter)) || default_render(assigns)
+      filter && process_filter_mod.render_process_info(assigns, filter) || default_render(assigns)
     else
       default_render(assigns)
     end

--- a/lib/phoenix/live_dashboard/info/process_info_component.ex
+++ b/lib/phoenix/live_dashboard/info/process_info_component.ex
@@ -2,8 +2,8 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
   use Phoenix.LiveDashboard.Web, :live_component
 
   alias Phoenix.LiveDashboard.SystemInfo
-
   @info_keys [
+    :pid,
     :initial_call,
     :registered_name,
     :current_function,
@@ -32,11 +32,24 @@ defmodule Phoenix.LiveDashboard.ProcessInfoComponent do
 
   @impl true
   def render(assigns) do
+
+    if process_filter_mod = Application.get_env(:phoenix_live_dashboard, :process_filter, nil) do
+      filter = assigns.page.params["filter"]
+      filter && process_filter_mod.render(Map.put(assigns, :filter, filter)) || default_render(assigns)
+    else
+      default_render(assigns)
+    end
+
+  end
+
+
+  defp default_render(assigns) do
     ~H"""
     <div class="tabular-info">
       <%= if @alive do %>
         <table class="table table-hover tabular-info-table">
           <tbody>
+
             <tr><td class="border-top-0">Registered name</td><td class="border-top-0"><pre><%= @registered_name %></pre></td></tr>
             <tr><td>Current function</td><td><pre><%= @current_function %></pre></td></tr>
             <tr><td>Initial call</td><td><pre><%= @initial_call %></pre></td></tr>

--- a/lib/phoenix/live_dashboard/pages/processes_page.ex
+++ b/lib/phoenix/live_dashboard/pages/processes_page.ex
@@ -15,7 +15,8 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
       id: @table_id,
       row_attrs: &row_attrs/1,
       row_fetcher: {&fetch_processes/3, nil},
-      title: "Processes"
+      title: "Processes",
+      filter: get_filter_list()
     )
   end
 
@@ -23,7 +24,7 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
     %{search: search, sort_by: sort_by, sort_dir: sort_dir, limit: limit} = params
 
     {processes, count, state} =
-      SystemInfo.fetch_processes(node, search, sort_by, sort_dir, limit, state)
+      SystemInfo.fetch_processes(node, params.filter, search, sort_by, sort_dir, limit, state)
 
     {processes, count, state}
   end
@@ -79,6 +80,13 @@ defmodule Phoenix.LiveDashboard.ProcessesPage do
       {"phx-value-info", encode_pid(process[:pid])},
       {"phx-page-loading", true}
     ]
+  end
+
+  defp get_filter_list() do
+    case Application.get_env(:phoenix_live_dashboard, :process_filter) do
+      nil -> nil
+      process_filter_module -> process_filter_module.list()
+    end
   end
 
   @impl true

--- a/lib/phoenix/live_dashboard/process_filter.ex
+++ b/lib/phoenix/live_dashboard/process_filter.ex
@@ -1,0 +1,18 @@
+defmodule Phoenix.LiveDashboard.ProcessFilter do
+  @callback list() :: [String.t()]
+  @callback filter(filter_name :: String.t()) :: [any()]
+  @callback render_process_info(assigns :: Socket.assigns(), filter_name :: String.t() | nil) :: Phoenix.LiveView.Rendered.t() | nil
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour Phoenix.LiveDashboard.ProcessFilter
+      def render_process_info(_assigns, _filter_name) do
+        nil
+      end
+
+      defoverridable render_process_info: 2
+    end
+  end
+
+
+end

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -219,7 +219,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
     next_state = for {_sorter, info} <- processes, into: %{}, do: {info[:pid], info[:reductions]}
 
-    count = if search, do: length(processes), else: :erlang.system_info(:process_count)
+    count = if search || process_filter, do: length(processes), else: :erlang.system_info(:process_count)
     processes = processes |> Enum.sort() |> Enum.take(limit) |> Enum.map(&elem(&1, 1))
 
     {processes, count, next_state}


### PR DESCRIPTION
Allow custom implementation of process lists. The motivation is to be able to inspect specific groups of processes rather than pulling the whole process list. For instance, we may want to look at the processes from the specific registry, supervised by a specific supervisor, etc.