### PR TITLE
Upgrade ecto_sqlite3_extras to 1.2.0

### DIFF
--- a/guides/ecto_stats.md
+++ b/guides/ecto_stats.md
@@ -48,7 +48,7 @@ To enable the "Ecto Stats" functionality for SQLite in your dashboard, you will 
 In your `mix.exs`, add the following to your `deps`:
 
 ```elixir
-  {:ecto_sqlite3_extras, "~> 1.0.0"},
+  {:ecto_sqlite3_extras, "~> 1.2.0"},
 ```
 
 ### Configure the dashboard

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Phoenix.LiveDashboard.MixProject do
       {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
       {:ecto_psql_extras, "~> 0.7", optional: true},
       {:ecto_mysql_extras, "~> 0.5", optional: true},
-      {:ecto_sqlite3_extras, "~> 1.1.7", optional: true},
+      {:ecto_sqlite3_extras, "~> 1.1.7 or ~> 1.2.0", optional: true},
       {:ecto, "~> 3.6.2 or ~> 3.7", optional: true},
 
       # Dev and test


### PR DESCRIPTION
Upgrade ecto_sqlite3_extras and fix documentation.

---

Current example version is broken:

```
─❯ mix deps.get
Resolving Hex dependencies...
Resolution completed in 0.024s
Because your app depends on ecto_sqlite3_extras ~> 1.0.0 which doesn't match any versions, version solving failed.
** (Mix) Hex dependency resolution failed
```

~~There's a version [1.2.0 of ecto_sqlite3_extras](https://github.com/orsinium-labs/ecto_sqlite3_extras/releases/tag/1.2.0), but it doesn't work either.~~ (fixed in this PR)

```
Because phoenix_live_dashboard >= 0.8.0 depends on ecto_sqlite3_extras ~> 1.1.7 and your app depends on ecto_sqlite3_extras ~> 1.2.0, phoenix_live_dashboard >= 0.8.0 is forbidden.
```