### PR TITLE
Fix @input to @output

### DIFF
--- a/lib/phoenix/live_dashboard/pages/home_page.ex
+++ b/lib/phoenix/live_dashboard/pages/home_page.ex
@@ -169,7 +169,7 @@ defmodule Phoenix.LiveDashboard.HomePage do
       </:col>
       <:col>
         <.card inner_title="Total output" inner_hint={hint_msg(:total_output)}>
-          <%= format_bytes(@input) %>
+          <%= format_bytes(@output) %>
         </.card>
       </:col>
     </.row>


### PR DESCRIPTION
 Possible typo. Fixed IO output variable from `@input` to `@output`.

Currently, the input and the output are showing the exact same value.
![Screenshot 2023-12-11 at 09 09 22](https://github.com/phoenixframework/phoenix_live_dashboard/assets/11752260/821ea798-384c-405e-a4e8-91c1348ff134)
