### PR TITLE
Add `:on_mount` to router documentation

### DIFF
--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -44,6 +44,10 @@ defmodule Phoenix.LiveDashboard.Router do
       If not set, metrics will start out empty/blank and only display
       data that occurs while the browser page is open.
 
+    * `:on_mount` - Declares a custom list of `Phoenix.LiveView.on_mount/1`
+      callbacks to add to the dashboard's `Phoenix.LiveView.Router.live_session/3`.
+      A single value may also be declared.
+
     * `:request_logger` - By default the Request Logger page is enabled. Passing
        `false` will disable this page.
 


### PR DESCRIPTION
I was super happy to find that the feature was added recently, but had to search the codebase and close issues list to discover it. Hopefully the included text is clear enough.