### PR TITLE
Wrap log lines in request logger page

### DIFF
--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -83,7 +83,7 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
         <div class="card-body">
           <div id="logger-messages" phx-update="stream">
             <%= for {id, {message, level}} <- @streams.messages do %>
-              <pre id={id} class={"log-level#{level}"}><%= message %></pre>
+              <pre id={id} class={"log-level#{level} text-wrap"}><%= message %></pre>
             <% end %>
           </div>
           <!-- Autoscroll ON/OFF checkbox -->


### PR DESCRIPTION
While trying to debug a page, I did not see expected output from `Logger`. That is my fault, it was there but on a single line that extended far to the right.

This wraps the output lines so the full content is on the screen.