### PR TITLE
Rename deprecated `push_redirect` to `push_navigate`

### DIFF
--- a/lib/phoenix/live_dashboard/page_live.ex
+++ b/lib/phoenix/live_dashboard/page_live.ex
@@ -288,7 +288,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
 
     if node && node != page.node do
       to = PageBuilder.live_dashboard_path(socket, page.route, node, page.params, page.params)
-      {:noreply, push_redirect(socket, to: to)}
+      {:noreply, push_navigate(socket, to: to)}
     else
       {:noreply, redirect_to_current_node(socket)}
     end
@@ -366,7 +366,7 @@ defmodule Phoenix.LiveDashboard.PageLive do
   end
 
   defp redirect_to_current_node(socket) do
-    push_redirect(socket, to: PageBuilder.live_dashboard_path(socket, :home, node(), %{}, %{}))
+    push_navigate(socket, to: PageBuilder.live_dashboard_path(socket, :home, node(), %{}, %{}))
   end
 
   defp update_page(socket, assigns) do

--- a/lib/phoenix/live_dashboard/pages/metrics_page.ex
+++ b/lib/phoenix/live_dashboard/pages/metrics_page.ex
@@ -18,7 +18,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
     cond do
       nav && is_nil(metrics) ->
         to = live_dashboard_path(socket, socket.assigns.page, nav: first_nav)
-        {:ok, push_redirect(socket, to: to)}
+        {:ok, push_navigate(socket, to: to)}
 
       metrics && connected?(socket) ->
         Phoenix.LiveDashboard.TelemetryListener.listen(socket.assigns.page.node, metrics)
@@ -27,7 +27,7 @@ defmodule Phoenix.LiveDashboard.MetricsPage do
 
       first_nav && is_nil(nav) ->
         to = live_dashboard_path(socket, socket.assigns.page, nav: first_nav)
-        {:ok, push_redirect(socket, to: to)}
+        {:ok, push_navigate(socket, to: to)}
 
       true ->
         {:ok, assign(socket, metrics: nil, nav: nav)}

--- a/lib/phoenix/live_dashboard/pages/request_logger_page.ex
+++ b/lib/phoenix/live_dashboard/pages/request_logger_page.ex
@@ -38,7 +38,7 @@ defmodule Phoenix.LiveDashboard.RequestLoggerPage do
   def mount(_, %{request_logger: _}, socket) do
     stream = :crypto.strong_rand_bytes(3) |> Base.url_encode64()
     to = live_dashboard_path(socket, socket.assigns.page, stream: stream)
-    {:ok, push_redirect(socket, to: to)}
+    {:ok, push_navigate(socket, to: to)}
   end
 
   @impl true


### PR DESCRIPTION
Removes the following compile time deprecation warnings:

```
==> phoenix_live_dashboard
Compiling 36 files (.ex)
    warning: Phoenix.LiveView.push_redirect/2 is deprecated. Use push_navigate/2 instead
    │
 21 │         {:ok, push_redirect(socket, to: to)}
    │               ~
    │
    └─ lib/phoenix/live_dashboard/pages/metrics_page.ex:21:15: Phoenix.LiveDashboard.MetricsPage.mount/3
    └─ lib/phoenix/live_dashboard/pages/metrics_page.ex:30:15: Phoenix.LiveDashboard.MetricsPage.mount/3

    warning: Phoenix.LiveView.push_redirect/2 is deprecated. Use push_navigate/2 instead
    │
 41 │     {:ok, push_redirect(socket, to: to)}
    │           ~
    │
    └─ lib/phoenix/live_dashboard/pages/request_logger_page.ex:41:11: Phoenix.LiveDashboard.RequestLoggerPage.mount/3

Upgrade some deps
     warning: Phoenix.LiveView.push_redirect/2 is deprecated. Use push_navigate/2 instead
     │
 291 │       {:noreply, push_redirect(socket, to: to)}
     │                  ~
     │
     └─ lib/phoenix/live_dashboard/page_live.ex:291:18: Phoenix.LiveDashboard.PageLive.handle_event/3
     └─ lib/phoenix/live_dashboard/page_live.ex:369:5: Phoenix.LiveDashboard.PageLive.redirect_to_current_node/1
```