### PR TITLE
Add Erlang/OTP 27 Process label support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           - pair:
               elixir: 1.15.6
               otp: 26.0.2
+          - pair:
+              elixir: 1.17.2
+              otp: 27.0.1
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -801,7 +801,12 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
       case Process.info(pid, [:initial_call, :dictionary, :registered_name]) do
         [{:initial_call, initial_call}, {:dictionary, dictionary}, {:registered_name, name}] ->
           initial_call = Keyword.get(dictionary, :"$initial_call", initial_call)
-          name = if is_atom(name), do: inspect(name), else: format_initial_call(initial_call)
+
+          name =
+            format_process_label(Keyword.get(dictionary, :"$process_label")) ||
+              format_registered_name(name) ||
+              format_initial_call(initial_call)
+
           {name, initial_call}
 
         _ ->
@@ -819,6 +824,13 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     Process.whereis(name)
     |> to_process_details()
   end
+
+  defp format_process_label(nil), do: nil
+  defp format_process_label(label) when is_binary(label), do: label
+  defp format_process_label(label), do: inspect(label)
+
+  defp format_registered_name([]), do: nil
+  defp format_registered_name(name), do: inspect(name)
 
   defp format_initial_call({:supervisor, mod, arity}), do: Exception.format_mfa(mod, :init, arity)
   defp format_initial_call({m, f, a}), do: Exception.format_mfa(m, f, a)


### PR DESCRIPTION
Support new `Process.set_label/1` from Elixir 1.17 & Erlang/OTP 27 (Issue #439)
Display process label as a name on Processes page if available.