### PR TITLE
Prefer process name over label if both are set

### DIFF
--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -803,8 +803,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
           initial_call = Keyword.get(dictionary, :"$initial_call", initial_call)
 
           name =
-            format_process_label(Keyword.get(dictionary, :"$process_label")) ||
-              format_registered_name(name) ||
+            format_registered_name(name) ||
+              format_process_label(Keyword.get(dictionary, :"$process_label")) ||
               format_initial_call(initial_call)
 
           {name, initial_call}

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -59,6 +59,18 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
         assert pid == {:pid, agent_pid}
         assert name == {:name_or_initial_call, "test label"}
       end
+
+      test "all with search by name if both name and label are set" do
+        {:ok, agent_pid} =
+          Agent.start_link(fn -> Process.set_label("test label") end, name: :test_agent)
+
+        {pids, _count, _} =
+          SystemInfo.fetch_processes(node(), "test_agent", :memory, :asc, 100)
+
+        assert [[pid, name | _]] = pids
+        assert pid == {:pid, agent_pid}
+        assert name == {:name_or_initial_call, ":test_agent"}
+      end
     end
 
     test "allows previous reductions param" do


### PR DESCRIPTION
Align label and name priority with Erlang observer for process label support introduced in #446