### PR TITLE
test: add edge case tests for TitleBarComponent

### DIFF
--- a/test/phoenix/live_dashboard/components/title_bar_component_test.exs
+++ b/test/phoenix/live_dashboard/components/title_bar_component_test.exs
@@ -18,7 +18,65 @@ defmodule Phoenix.LiveDashboard.TitleBarComponentTest do
 
       assert result =~ "123"
       assert result =~ ~R|<style nonce="style_nonce">\s*#.*\{width:0.1%\}|
-      assert result =~ "div class=\"test-class\""
+      assert result =~ ~r|<div class="test-class"|
+    end
+
+    test "handles negative and over-max percent values" do
+      result_negative = render_component(TitleBarComponent,
+        percent: -0.5,
+        class: "test-class",
+        csp_nonces: %{img: "img_nonce", style: "style_nonce", script: "script_nonce"},
+        dom_id: "title-bar",
+        inner_block: [%{slot: :__inner_block__, inner_block: fn _, _ -> "Negative" end}]
+      )
+
+      assert result_negative =~ "Negative"
+      assert result_negative =~ ~R|<style nonce="style_nonce">\s*#.*\{width:0%\}|
+
+      result_over_max = render_component(TitleBarComponent,
+        percent: 1.5,
+        class: "test-class",
+        csp_nonces: %{img: "img_nonce", style: "style_nonce", script: "script_nonce"},
+        dom_id: "title-bar",
+        inner_block: [%{slot: :__inner_block__, inner_block: fn _, _ -> "Over max" end}]
+      )
+
+      assert result_over_max =~ "Over max"
+      assert result_over_max =~ ~R|<style nonce="style_nonce">\s*#.*\{width:100%\}|
+    end
+
+    test "handles empty or missing nonces" do
+      result_empty_nonce = render_component(TitleBarComponent,
+        percent: 0.5,
+        class: "test-class",
+        csp_nonces: %{img: "", style: "style_nonce", script: ""},
+        dom_id: "title-bar",
+        inner_block: [%{slot: :__inner_block__, inner_block: fn _, _ -> "Empty nonce" end}]
+      )
+
+      assert result_empty_nonce =~ "Empty nonce"
+      assert result_empty_nonce =~ ~R|<style nonce="style_nonce">\s*#.*\{width:50%\}|
+      
+      result_missing_nonce = render_component(TitleBarComponent,
+        percent: 0.5,
+        class: "test-class",
+        dom_id: "title-bar",
+        inner_block: [%{slot: :__inner_block__, inner_block: fn _, _ -> "Missing nonce" end}]
+      )
+
+      assert result_missing_nonce =~ "Missing nonce"
+      assert result_missing_nonce =~ ~R|<style>\s*#.*\{width:50%\}|
+    end
+
+    test "renders without inner_block" do
+      result_no_inner_block = render_component(TitleBarComponent,
+        percent: 0.5,
+        class: "test-class",
+        csp_nonces: %{img: "img_nonce", style: "style_nonce", script: "script_nonce"},
+        dom_id: "title-bar"
+      )
+
+      assert result_no_inner_block =~ ~R|<style nonce="style_nonce">\s*#.*\{width:50%\}|
     end
   end
 end


### PR DESCRIPTION
### Overview
This PR adds additional test coverage to `TitleBarComponent` in order to handle some edge cases that were previously untested. Specifically, it introduces tests for the following scenarios:

1. **Percent values:**
   - Negative percentages (e.g., `-0.5`) should clamp to `0%` width.
   - Percentages over `1` (e.g., `1.5`) should clamp to `100%` width.

2. **CSP Nonces:**
   - Empty nonces for `img`, `style`, or `script` are now tested to ensure proper rendering.
   - Tests for the component's behavior when nonces are missing entirely.

3. **Missing inner_block:**
   - Verified that the component renders gracefully even if no `inner_block` is provided.

This adds robustness and prevents edge cases from slipping through, especially in production environments where edge inputs might lead to unexpected behavior.

### Changes Made
- Expanded test cases in `test/phoenix/live_dashboard/components/title_bar_component_test.exs` to cover edge scenarios for `percent`, `csp_nonces`, and `inner_block`.
- Minor adjustment to an assertion to fix a potential typo (`div class="test-class"` should be `<div class="test-class">`).

Looking forward to feedback! 🚀
