### PR TITLE
Fix typos in variables

### DIFF
--- a/lib/phoenix/live_dashboard/reingold_tilford.ex
+++ b/lib/phoenix/live_dashboard/reingold_tilford.ex
@@ -246,7 +246,7 @@ defmodule Phoenix.LiveDashboard.ReingoldTilford do
   def lines(%{children: children} = node) do
     lines_to_children = lines_to_children(node)
 
-    aditional_lines =
+    additional_lines =
       cond do
         [node] == children ->
           [child | _] = children
@@ -261,7 +261,7 @@ defmodule Phoenix.LiveDashboard.ReingoldTilford do
       end
 
     children_lines = Enum.flat_map(children, &lines/1)
-    lines_to_children ++ aditional_lines ++ children_lines
+    lines_to_children ++ additional_lines ++ children_lines
   end
 
   defp line_from_parent(node, child) do

--- a/lib/phoenix/live_dashboard/system_info.ex
+++ b/lib/phoenix/live_dashboard/system_info.ex
@@ -280,7 +280,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   @doc false
   def processes_callback(search, sort_by, sort_dir, limit, prev_reductions) do
-    multiplier = sort_dir_multipler(sort_dir)
+    multiplier = sort_dir_multiplier(sort_dir)
 
     processes =
       for pid <- Process.list(),
@@ -526,7 +526,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
 
   @doc false
   def ports_callback(search, sort_by, sort_dir, limit) do
-    multiplier = sort_dir_multipler(sort_dir)
+    multiplier = sort_dir_multiplier(sort_dir)
 
     ports =
       for port <- Port.list(), port_info = port_info(port), show_port?(port_info, search) do
@@ -574,7 +574,7 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
   ## ETS callbacks
 
   def ets_callback(search, sort_by, sort_dir, limit) do
-    multiplier = sort_dir_multipler(sort_dir)
+    multiplier = sort_dir_multiplier(sort_dir)
 
     tables =
       for ref <- :ets.all(), info = ets_info(ref), show_ets?(info, search) do
@@ -788,8 +788,8 @@ defmodule Phoenix.LiveDashboard.SystemInfo do
     end
   end
 
-  defp sort_dir_multipler(:asc), do: 1
-  defp sort_dir_multipler(:desc), do: -1
+  defp sort_dir_multiplier(:asc), do: 1
+  defp sort_dir_multiplier(:desc), do: -1
 
   defp pid_or_port_details(pid) when is_pid(pid), do: to_process_details(pid)
   defp pid_or_port_details(name) when is_atom(name), do: to_process_details(name)


### PR DESCRIPTION
Found via `typos --hidden --format brief`