### PR TITLE
Relax deps for phoenix_live_view to include 1.0-rc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Phoenix.LiveDashboard.MixProject do
     [
       # Actual deps
       {:mime, "~> 1.6 or ~> 2.0"},
-      {:phoenix_live_view, "~> 0.19 or ~> 1.0", phoenix_live_view_opts()},
+      {:phoenix_live_view, "~> 0.19 or ~> 1.0-rc or ~> 1.0", phoenix_live_view_opts()},
       {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
       {:ecto_psql_extras, "~> 0.7", optional: true},
       {:ecto_mysql_extras, "~> 0.5", optional: true},


### PR DESCRIPTION
Would this make sense to include? 

```elixir
Version.match?("1.0.0-rc.7", "~> 0.19 or ~> 1.0")
false
Version.match?("1.0.0-rc.7", "~> 0.19 or ~> 1.0-rc or ~> 1.0")
true
```