### PR TITLE
Build assets on CI and add caching

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,60 @@
+name: Assets
+
+on:
+  push:
+    branches:
+      - main
+      - "v*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      elixir: 1.14.0
+      otp: 24.3
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.elixir }}
+          otp-version: ${{ env.otp }}
+
+      - name: Cache Mix
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}-dev
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-
+
+      - name: Install Dependencies
+        run: mix deps.get --only dev
+
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm dependencies
+        run: npm ci --prefix assets
+
+      - name: Build assets
+        run: mix assets.build
+
+      - name: Push updated assets
+        id: push_assets
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update assets
+          file_pattern: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
+      - name: Cache Mix
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-${{ hashFiles('**/mix.lock') }}-test
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-
+
       - name: Install Dependencies
         run: mix deps.get --only test
 
@@ -78,6 +88,16 @@ jobs:
           elixir-version: 1.14.0
           otp-version: 24.3
 
+      - name: Cache Mix
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-${{ hashFiles('**/mix.lock') }}-test
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-
+
       - name: Install Dependencies
         run: mix deps.get --only test
 
@@ -85,6 +105,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: npm install and test
         run: |


### PR DESCRIPTION
Currently assets need to be built manually, which can be forgotten. Also, sometimes non-minified dist is merged in PRs. This adds a workflow to automatically build the assets (particularly useful when installing phoenix_live_dashboard directly from github).

I also added caching to the existing workflow for faster builds.

I tested that both workflows work on the fork :)