### PR TITLE
Update ecto_psql_extras version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Phoenix.LiveDashboard.MixProject do
       {:mime, "~> 1.6 or ~> 2.0"},
       {:phoenix_live_view, "~> 0.19 or ~> 1.0", phoenix_live_view_opts()},
       {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
-      {:ecto_psql_extras, "~> 0.7", optional: true},
+      {:ecto_psql_extras, "~> 0.8", optional: true},
       {:ecto_mysql_extras, "~> 0.5", optional: true},
       {:ecto_sqlite3_extras, "~> 1.1.7 or ~> 1.2.0", optional: true},
       {:ecto, "~> 3.6.2 or ~> 3.7", optional: true},


### PR DESCRIPTION
Hi. This PR updates version for https://github.com/pawurb/ecto_psql_extras . I've double checked it's compatible. I'm now working on adding a new feature [related to fk columns](https://github.com/pawurb/rails-pg-extras?tab=readme-ov-file#missing_fk_indexes) so would be great if it can be included by default. 