### PR TITLE
css fixes for chart legends height changes on hover

### DIFF
--- a/assets/css/app/components/_charts.scss
+++ b/assets/css/app/components/_charts.scss
@@ -115,14 +115,14 @@
 }
 
 /* Override uPlot styles */
-/* Avoid wrapping for long legend titles when data is shown for that row, changes the legend heights */
+/* Avoid wrapping for long legend titles when data is shown for that row on hover, changes the legend heights */
 .u-series {
   th {
     text-wrap: nowrap;
   }
 }
 
-/* Avoid block styles for legends, leads to chart card size updates and hopping */
+/* Avoid block styles for legends, leads to chart card size updates and hopping on hover */
 .u-inline {
   display: flex;
   flex-direction: column;

--- a/assets/css/app/components/_charts.scss
+++ b/assets/css/app/components/_charts.scss
@@ -114,6 +114,20 @@
   }
 }
 
+/* Override uPlot styles */
+/* Avoid wrapping for long legend titles when data is shown for that row, changes the legend heights */
+.u-series {
+  th {
+    text-wrap: nowrap;
+  }
+}
+
+/* Avoid block styles for legends, leads to chart card size updates and hopping */
+.u-inline {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (min-width: map-get($grid-breakpoints, xxl)) {
   [data-phx-view="LiveDashboard.MetricsLive"] #main.container{
     max-width: 95%;


### PR DESCRIPTION
Hovering on charts may lead to legends changing heights and charts hopping up and down.
This over-rides some of the uplot css to make sure legends block has a fixed height even when hovering on charts changes the data columns.

Before:
<video src="https://github.com/user-attachments/assets/43a2a7ce-b62d-445b-9256-434b1886901d"></video>


After:
<video src="https://github.com/user-attachments/assets/ea7fdcf9-9aa6-4d90-b19f-1541302a2db6"></video>

Please let me know if I need to make any changes to the PR.