### PR TITLE
Include more recent OTP versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
           - pair:
               elixir: 1.17.2
               otp: 27.0.1
+          - pair:
+              elixir: 1.19.5
+              otp: 28.5.0.3
+          - pair:
+              elixir: 1.20.2
+              otp: 29.0.3
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/test/phoenix/live_dashboard/pages/processes_live_test.exs
+++ b/test/phoenix/live_dashboard/pages/processes_live_test.exs
@@ -110,7 +110,7 @@ defmodule Phoenix.LiveDashboard.ProcessesLiveTest do
     assert rendered =~ ~r/Registered name.*Phoenix.LiveDashboard.DynamicSupervisor/
     assert rendered =~ ~r/Initial call.*Supervisor.Default.init\/1/
 
-    refute live |> element("#modal-close") |> render_click() =~ "modal"
+    refute live |> element("#modal-close") |> render_click() =~ "modal-content"
     return_path = processes_path(10, "", :message_queue_len, :desc)
     assert_patch(live, return_path)
   end

--- a/test/phoenix/live_dashboard/system_info_test.exs
+++ b/test/phoenix/live_dashboard/system_info_test.exs
@@ -85,11 +85,19 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
       {:ok, info} = SystemInfo.fetch_process_info(Process.whereis(:user))
       assert info[:registered_name] == :user
       assert is_integer(info[:message_queue_len])
+      otp_release = String.to_integer(System.otp_release())
 
       expected =
-        if System.otp_release() |> String.to_integer() >= 26,
-          do: {:group, :server, 4},
-          else: {:erlang, :apply, 2}
+        cond do
+          otp_release >= 28 ->
+            {:group, :init, 1}
+
+          otp_release >= 26 ->
+            {:group, :server, 4}
+
+          true ->
+            {:erlang, :apply, 2}
+        end
 
       assert info[:initial_call] == expected
 
@@ -197,7 +205,19 @@ defmodule Phoenix.LiveDashboard.SystemInfoTest do
     test "all with search" do
       open_socket()
 
-      {[socket], _count} = SystemInfo.fetch_sockets(node(), "*:*", :send_oct, :asc, 100)
+      socket =
+        if String.to_integer(System.otp_release()) >= 28 do
+          assert {[socket, _other], _count} =
+                   SystemInfo.fetch_sockets(node(), "*:*", :send_oct, :asc, 100)
+
+          socket
+        else
+          assert {[socket], _count} =
+                   SystemInfo.fetch_sockets(node(), "*:*", :send_oct, :asc, 100)
+
+          socket
+        end
+
       assert socket[:foreign_address] == "*:*"
       {sockets, _count} = SystemInfo.fetch_sockets(node(), "impossible", :send_oct, :asc, 100)
       assert Enum.empty?(sockets)


### PR DESCRIPTION
The OTP 24 can probably be dropped as well, unless there is a specific
reason for it.
