### PR TITLE
Allow custom info module for Ecto repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add a compact nested list view for application supervision trees
+* Allow overriding the Ecto Stats info module per repository by passing `{repo, info_module}` tuples in `:ecto_repos`
 
 ## v0.8.7 (2025-04-28)
 

--- a/guides/ecto_stats.md
+++ b/guides/ecto_stats.md
@@ -1,6 +1,6 @@
 # Configuring Ecto repository stats
 
-This guide covers how to configure the LiveDashboard to show stats from your underlying database. At the moment, these stats can only be shown for Ecto repositories running on `Ecto.Adapters.Postgres` or `Ecto.Adapters.MyXQL`.
+This guide covers how to configure the LiveDashboard to show stats from your underlying database. These stats are shown for Ecto repositories running on `Ecto.Adapters.Postgres`, `Ecto.Adapters.MyXQL`, or `Ecto.Adapters.SQLite3`. You can also [override the info module](#overriding-the-info-module) used for a repository — for example, for a PostgreSQL-compatible database that needs different queries.
 
 ## Installing Ecto Stats
 
@@ -62,7 +62,7 @@ Go to the `live_dashboard` call in your router and list your repositories:
 live_dashboard "/dashboard", ecto_repos: [MyApp.Repo]
 ```
 
-You want to list all repositories that connect to distinct databases. For example, if you have both `MyApp.Repo` and `MyApp.RepoAnother` but they connect to the same database, there is no benefit in listing both. Remember only Ecto repositories running on `Ecto.Adapters.Postgres` or `Ecto.Adapters.MyXQL` are currently supported.
+You want to list all repositories that connect to distinct databases. For example, if you have both `MyApp.Repo` and `MyApp.RepoAnother` but they connect to the same database, there is no benefit in listing both. Repositories running on `Ecto.Adapters.Postgres`, `Ecto.Adapters.MyXQL`, or `Ecto.Adapters.SQLite3` are detected automatically. To customize the queries used for a repository, see [Overriding the info module](#overriding-the-info-module).
 
 If you want to disable the "Ecto Stats" option altogether, set `ecto_repos: []`.
 
@@ -103,6 +103,23 @@ live_dashboard "/dashboard",
 ```
 
 See the [`ecto_sqlite3_extras` documentation](https://github.com/orsinium-labs/ecto_sqlite3_extras) for available options.
+
+### Overriding the info module
+
+By default, the module used to load the stats — the "info module" — is inferred from each repository's adapter:
+
+- `Ecto.Adapters.Postgres` uses `EctoPSQLExtras`
+- `Ecto.Adapters.MyXQL` uses `EctoMySQLExtras`
+- `Ecto.Adapters.SQLite3` uses `EctoSQLite3Extras`
+
+You can override this by listing a repository as a `{repo, info_module}` tuple instead of a bare module:
+
+```elixir
+live_dashboard "/dashboard",
+  ecto_repos: [MyApp.Repo, {MyApp.CompatRepo, MyApp.CompatExtras}]
+```
+
+This is useful for a PostgreSQL-compatible database that runs on `Ecto.Adapters.Postgres` — and so is detected as `EctoPSQLExtras` — but needs a different set of queries. You can point it at an info module with queries tailored to that database instead. The given `info_module` must implement the same API as `EctoPSQLExtras`, `EctoMySQLExtras`, and `EctoSQLite3Extras`.
 
 ### Install custom PostgreSQL extensions
 

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -14,7 +14,14 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
         ecto_mysql_extras_options: ecto_mysql_extras_options,
         ecto_sqlite3_extras_options: ecto_sqlite3_extras_options
       }) do
-    capabilities = for repo <- List.wrap(repos), do: {:process, repo}
+    capabilities =
+      for repo <- List.wrap(repos) do
+        case repo do
+          {repo, _} -> {:process, repo}
+          repo -> {:process, repo}
+        end
+      end
+
     repos = repos || :auto_discover
 
     {:ok,
@@ -46,6 +53,14 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
 
     case result do
       {:ok, repos} ->
+        repos =
+          for repo <- repos do
+            case repo do
+              {_repo, _info_module} -> repo
+              repo -> {repo, info_module_for(socket.assigns.page.node, repo)}
+            end
+          end
+
         {:ok, assign(socket, :repos, repos)}
 
       {:error, error} ->
@@ -74,7 +89,12 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
         {:error, :cannot_list_running_repos}
     else
       repos when is_list(repos) ->
-        {:ok, Enum.filter(repos, fn repo -> extra_available?(node, repo) end)}
+        repos =
+          for repo <- repos, extra_available?(repo) do
+            {repo, info_module_for(node, repo)}
+          end
+
+        {:ok, repos}
     end
   end
 
@@ -96,21 +116,39 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
 
   @impl true
   def menu_link(%{repos: repos}, capabilities) do
+    none_in_caps? =
+      not Enum.any?(repos, fn repo ->
+        repo =
+          case repo do
+            {repo, _} -> repo
+            repo -> repo
+          end
+
+        repo in capabilities.processes
+      end)
+
     cond do
-      Enum.all?(repos, fn repo -> repo not in capabilities.processes end) ->
-        :skip
-
-      extra_available_for_any?(Node.self(), repos) ->
-        {:ok, @page_title}
-
-      true ->
-        {:disabled, @page_title, @disabled_link}
+      none_in_caps? -> :skip
+      extra_available_for_any?(Node.self(), repos) -> {:ok, @page_title}
+      true -> {:disabled, @page_title, @disabled_link}
     end
   end
 
   defp extra_available_for_any?(node, repos) do
-    Enum.any?(repos, fn repo -> extra_available?(node, repo) end)
+    Enum.any?(repos, fn repo ->
+      case repo do
+        {_repo, extra} ->
+          extra != nil && Code.ensure_loaded?(extra)
+
+        repo ->
+          extra_available?(node, repo)
+      end
+    end)
   end
+
+  defp extra_available?(nil), do: false
+
+  defp extra_available?(repo), do: Code.ensure_loaded?(repo)
 
   defp extra_available?(node, repo) when is_atom(repo) do
     extra = info_module_for(node, repo)
@@ -124,6 +162,10 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
   # user does not need to have extra module installed on every node.
   defp extra_loaded?(extra) do
     Code.ensure_loaded?(extra)
+  end
+
+  defp info_module_for(_node, {_repo, info_module}) do
+    info_module
   end
 
   defp info_module_for(node, repo) do
@@ -148,12 +190,12 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
         style={:bar}
         extra_params={["nav"]}
       >
-        <:item :for={repo <- @repos} name={inspect(repo)} label={inspect(repo)}>
+        <:item :for={{repo, info_module} <- @repos} name={inspect(repo)} label={inspect(repo)}>
           <.render_repo_tab
             page={@page}
             repo={repo}
             ecto_options={@ecto_options}
-            info_module={info_module_for(@page.node, repo)}
+            info_module={info_module}
           />
         </:item>
       </.live_nav_bar>

--- a/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
+++ b/lib/phoenix/live_dashboard/pages/ecto_stats_page.ex
@@ -164,10 +164,6 @@ defmodule Phoenix.LiveDashboard.EctoStatsPage do
     Code.ensure_loaded?(extra)
   end
 
-  defp info_module_for(_node, {_repo, info_module}) do
-    info_module
-  end
-
   defp info_module_for(node, repo) do
     case :erpc.call(node, repo, :__adapter__, []) do
       Ecto.Adapters.Postgres -> EctoPSQLExtras

--- a/lib/phoenix/live_dashboard/router.ex
+++ b/lib/phoenix/live_dashboard/router.ex
@@ -26,6 +26,12 @@ defmodule Phoenix.LiveDashboard.Router do
       auto-discover the available repositories. You can disable this behavior
       by setting `[]` to this option.
 
+      Each entry can be a repository module or a `{repo, info_module}` tuple.
+      In the tuple form, `info_module` is the "extras" module used to load the
+      stats — `EctoPSQLExtras`, `EctoMySQLExtras`, `EctoSQLite3Extras`, or any
+      module implementing the same API — and overrides the one that would
+      otherwise be inferred from the repository's adapter.
+
     * `:env_keys` - Configures environment variables to display.
       It is defined as a list of string keys. If not set, the environment
       information will not be displayed
@@ -450,6 +456,9 @@ defmodule Phoenix.LiveDashboard.Router do
   defp validate_requirements(module, requirements) do
     Enum.each(requirements, fn
       {key, value} when key in [:application, :module, :process] and is_atom(value) ->
+        :ok
+
+      {key, {value, _}} when key in [:application, :module, :process] and is_atom(value) ->
         :ok
 
       other ->

--- a/test/phoenix/live_dashboard/pages/ecto_stats_page_test.exs
+++ b/test/phoenix/live_dashboard/pages/ecto_stats_page_test.exs
@@ -10,6 +10,7 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
   alias Phoenix.LiveDashboardTest.PGRepo
   alias Phoenix.LiveDashboardTest.MySQLRepo
   alias Phoenix.LiveDashboardTest.SQLiteRepo
+  alias Phoenix.LiveDashboardTest.CustomRepo
 
   test "menu_link/2" do
     assert :skip = EctoStatsPage.menu_link(%{repos: []}, %{})
@@ -19,6 +20,33 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
 
     assert {:ok, "Ecto Stats"} =
              EctoStatsPage.menu_link(%{repos: :auto_discover}, %{processes: []})
+
+    # A repo configured with an explicit info module, i.e. `{repo, info_module}`
+    assert :skip =
+             EctoStatsPage.menu_link(%{repos: [{CustomRepo, EctoPSQLExtras}]}, %{processes: []})
+
+    assert {:ok, "Ecto Stats"} =
+             EctoStatsPage.menu_link(
+               %{repos: [{CustomRepo, EctoPSQLExtras}]},
+               %{processes: [CustomRepo]}
+             )
+
+    # The configured info module is not available
+    assert {:disabled, "Ecto Stats", _} =
+             EctoStatsPage.menu_link(%{repos: [{CustomRepo, nil}]}, %{processes: [CustomRepo]})
+  end
+
+  test "init/1 builds process capabilities for repos with a custom info module" do
+    assert {:ok, session, capabilities} =
+             EctoStatsPage.init(%{
+               repos: [Repo, {CustomRepo, EctoPSQLExtras}],
+               ecto_psql_extras_options: [],
+               ecto_mysql_extras_options: [],
+               ecto_sqlite3_extras_options: []
+             })
+
+    assert session.repos == [Repo, {CustomRepo, EctoPSQLExtras}]
+    assert capabilities == [process: Repo, process: CustomRepo]
   end
 
   test "renders" do
@@ -31,6 +59,7 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
     refute rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
     refute rendered =~ "Phoenix.LiveDashboardTest.MySQLRepo"
     refute rendered =~ "Phoenix.LiveDashboardTest.SQLiteRepo"
+    refute rendered =~ "Phoenix.LiveDashboardTest.CustomRepo"
     assert rendered =~ ~r"Showing \d+ entries"
 
     start_pg_repo!()
@@ -59,6 +88,17 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
     assert rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
     assert rendered =~ "Phoenix.LiveDashboardTest.MySQLRepo"
     assert rendered =~ "Phoenix.LiveDashboardTest.SQLiteRepo"
+
+    start_custom_repo!()
+
+    {:ok, live, _} = live(build_conn(), ecto_stats_path())
+    rendered = render(live)
+
+    assert rendered =~ "Phoenix.LiveDashboardTest.Repo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.PGRepo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.MySQLRepo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.SQLiteRepo"
+    assert rendered =~ "Phoenix.LiveDashboardTest.CustomRepo"
   end
 
   test "renders error without running repos" do
@@ -208,5 +248,9 @@ defmodule Phoenix.LiveDashboard.EctoStatsPageTest do
 
   defp start_sqlite_repo! do
     start_supervised!(SQLiteRepo)
+  end
+
+  defp start_custom_repo! do
+    start_supervised!(CustomRepo)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -44,6 +44,16 @@ end
 
 _ = Ecto.Adapters.SQLite3.storage_up(Phoenix.LiveDashboardTest.SQLiteRepo.config())
 
+Application.put_env(:phoenix_live_dashboard, Phoenix.LiveDashboardTest.CustomRepo,
+  url: "ecto://#{pg_url}/phx_dashboard_test"
+)
+
+defmodule Phoenix.LiveDashboardTest.CustomRepo do
+  use Ecto.Repo, otp_app: :phoenix_live_dashboard, adapter: Ecto.Adapters.Postgres
+end
+
+_ = Ecto.Adapters.Postgres.storage_up(Phoenix.LiveDashboardTest.CustomRepo.config())
+
 Application.put_env(:phoenix_live_dashboard, Phoenix.LiveDashboardTest.Endpoint,
   url: [host: "localhost", port: 4000],
   secret_key_base: "Hu4qQN3iKzTV4fJxhorPQlA/osH9fAMtbtjVS58PFgfw3ja5Z18Q/WSNR9wP4OfW",


### PR DESCRIPTION
This allows you to include a tuple of `{RepoMod, InfoMod}` instead of
just `RepoMod` when configuring your Ecto repos for the Ecto Stats page.

This is useful for databases that re-use an adapter (e.g., for
CockroachDB, we use the Postgres adapter) but `ecto_psql_extras` is not
applicable for us, so we can configure it to use an arbitrary info
module that adheres to the same interface as the other `_extras`
packages.

## Alternate approach

An alternate approach could be to put this into application configuration, but that adds another vector for
configuration, so I figured that the current approach is the most in line with the current API.

Please let me know what you think, we are planning to use this with CockroachDB.
